### PR TITLE
Make RxPy compatible with python 2.7

### DIFF
--- a/rx/checkedobserver.py
+++ b/rx/checkedobserver.py
@@ -35,17 +35,18 @@ class CheckedObserver(Observer):
         if self._state == 0:
             self._state = 1
 
-    def checked(self):
-        """Checks access to the observer for grammar violations. This includes
-        checking for multiple OnError or OnCompleted calls, as well as 
-        reentrancy in any of the observer methods. If a violation is detected, 
-        an Error is thrown from the offending observer method call.
-        
-        Returns an observer that checks callbacks invocations against the 
-        observer grammar and, if the checks pass, forwards those to the 
-        specified observer.
-        """
-        return CheckedObserver(self)
 
-Observer.checked = CheckedObserver.checked
- 
+def checked(self):
+    """Checks access to the observer for grammar violations. This includes
+    checking for multiple OnError or OnCompleted calls, as well as
+    reentrancy in any of the observer methods. If a violation is detected,
+    an Error is thrown from the offending observer method call.
+
+    Returns an observer that checks callbacks invocations against the
+    observer grammar and, if the checks pass, forwards those to the
+    specified observer.
+    """
+    return CheckedObserver(self)
+
+CheckedObserver.checked = checked
+Observer.checked = checked

--- a/rx/concurrency/scheduler.py
+++ b/rx/concurrency/scheduler.py
@@ -34,21 +34,20 @@ class Scheduler(object):
         """
 
         period /= 1000.0
-        timer = None
-        s = state
-        
-        def interval():
-            nonlocal timer, s
-            s = action(s)
-            
-            timer = Timer(period, interval)
-            timer.start()
+        timer = [None]
+        s = [state]
 
-        timer = Timer(period, interval)
-        timer.start()
+        def interval():
+            s[0] = action(s[0])
+            
+            timer[0] = Timer(period, interval)
+            timer[0].start()
+
+        timer[0] = Timer(period, interval)
+        timer[0].start()
         
         def dispose():
-            timer.cancel()
+            timer[0].cancel()
 
         return Disposable(dispose)
 
@@ -63,23 +62,21 @@ class Scheduler(object):
             def action2(state2=None):
                 #print "action2", state2
                 is_added = False
-                is_done = False
+                is_done = [False]
                 
                 def action(scheduler, state=None):
-                    nonlocal is_done
-
                     #print "action", scheduler1, state3
                     if is_added:
                         group.remove(d)
                     else:
-                        is_done = True
+                        is_done[0] = True
                     
                     recursive_action(state)
                     return Disposable.empty()
 
                 d = scheduler.schedule(action, state2)
                 
-                if not is_done:
+                if not is_done[0]:
                     group.add(d)
                     is_added = True
 
@@ -95,21 +92,20 @@ class Scheduler(object):
         
         def recursive_action(state1):
             def action1(state2, duetime1):
-                is_added, is_done = False, False
+                is_added = False
+                is_done = [False]
 
                 def action2(scheduler1, state3):
-                    nonlocal is_done
-
                     if is_added:
                         group.remove(d)
                     else:
-                        is_done = True
+                        is_done[0] = True
                     
                     recursive_action(state3)
                     return Disposable.empty()
                 
                 d = getattr(scheduler, method)(duetime1, action2, state2)
-                if not is_done:
+                if not is_done[0]:
                     group.add(d)
                     is_added = True
                 

--- a/rx/concurrency/timeoutscheduler.py
+++ b/rx/concurrency/timeoutscheduler.py
@@ -41,7 +41,7 @@ class TimeoutScheduler(Scheduler):
             log.info("TimeoutScheduler:schedule_relative.interval()")
             disposable.disposable = action(scheduler, state)
         
-        seconds = dt.seconds+dt.microseconds/1000000
+        seconds = dt.seconds+dt.microseconds/1000000.0
         log.info("timeout: %s" % seconds)
         self.timer = Timer(seconds, interval)
         self.timer.start()

--- a/rx/linq/observable_aggregates.py
+++ b/rx/linq/observable_aggregates.py
@@ -1,9 +1,11 @@
+from six import add_metaclass
 from rx import AnonymousObservable, Observable
 from rx.observable import ObservableMeta
 from rx.observeonobserver import ObserveOnObserver
 from rx.disposables import SingleAssignmentDisposable, SerialDisposable, ScheduledDisposable
 
-class ObservableAggregates(Observable, metaclass=ObservableMeta):
+@add_metaclass(ObservableMeta)
+class ObservableAggregates(Observable):
 
     def aggregate(self, accumulator, seed=None):
         """Applies an accumulator function over an observable sequence, 

--- a/rx/linq/observable_coincidence.py
+++ b/rx/linq/observable_coincidence.py
@@ -1,5 +1,6 @@
 import logging
 from collections import OrderedDict
+from six import add_metaclass
 
 from rx import AnonymousObservable, Observable
 from rx.internal.utils import add_ref
@@ -10,7 +11,8 @@ from rx.disposables import SingleAssignmentDisposable, SerialDisposable, Composi
 
 log = logging.getLogger("Rx")
 
-class ObservableCoincidence(Observable, metaclass=ObservableMeta):
+@add_metaclass(ObservableMeta)
+class ObservableCoincidence(Observable):
 
     def join(self, right, left_duration_selector, right_duration_selector, result_selector):
         """Correlates the elements of two sequences based on overlapping durations.

--- a/rx/linq/observable_coincidence.py
+++ b/rx/linq/observable_coincidence.py
@@ -1,6 +1,6 @@
 import logging
 from collections import OrderedDict
-from six import add_metaclass
+import six
 
 from rx import AnonymousObservable, Observable
 from rx.internal.utils import add_ref
@@ -11,7 +11,7 @@ from rx.disposables import SingleAssignmentDisposable, SerialDisposable, Composi
 
 log = logging.getLogger("Rx")
 
-@add_metaclass(ObservableMeta)
+@six.add_metaclass(ObservableMeta)
 class ObservableCoincidence(Observable):
 
     def join(self, right, left_duration_selector, right_duration_selector, result_selector):
@@ -74,7 +74,7 @@ class ObservableCoincidence(Observable):
                     return
                 
                 md.disposable = duration.take(1).subscribe(noop, observer.on_error, lambda: expire())
-                values = right_map.values()
+                values = six.itervalues(right_map)
                 for val in values:
                     try:
                         result = result_selector(value, val)
@@ -116,7 +116,7 @@ class ObservableCoincidence(Observable):
                     return
                 
                 md.disposable = duration.take(1).subscribe(noop, observer.on_error, lambda: expire())
-                values = left_map.values()
+                values = six.itervalues(left_map)
                 for val in values:
                     try:
                         result = result_selector(val, value)
@@ -225,7 +225,7 @@ class ObservableCoincidence(Observable):
                     expire)
             
             def on_error_left(e):
-                left_values = left_map.values()
+                left_values = six.itervalues(left_map)
                 for left_value in left_values:
                     left_value.on_error(e)
                 
@@ -273,7 +273,7 @@ class ObservableCoincidence(Observable):
                     left_values.on_next(value)
             
             def on_error_right(e):
-                left_values = left_map.values()
+                left_values = six.itervalues(left_map)
                 for left_value in left_values:
                     left_value.on_error(e)
                 

--- a/rx/linq/observable_coincidence.py
+++ b/rx/linq/observable_coincidence.py
@@ -37,19 +37,17 @@ class ObservableCoincidence(Observable, metaclass=ObservableMeta):
 
         def subscribe(observer):
             group = CompositeDisposable()
-            left_done = False
+            left_done = [False]
             left_map = OrderedDict()
-            left_id = 0
-            right_done = False
+            left_id = [0]
+            right_done = [False]
             right_map = OrderedDict()
-            right_id = 0
+            right_id = [0]
             
             def on_next_left(value):
-                nonlocal left_id
-
                 duration = None
-                current_id = left_id
-                left_id += 1
+                current_id = left_id[0]
+                left_id[0] += 1
                 md = SingleAssignmentDisposable()
                 
                 #log.debug("**** left_map[%s] = %s" % (current_id, value))
@@ -61,7 +59,7 @@ class ObservableCoincidence(Observable, metaclass=ObservableMeta):
                 def expire():
                     if current_id in left_map:
                         del left_map[current_id]
-                    if not len(left_map) and left_done:
+                    if not len(left_map) and left_done[0]:
                         observer.on_completed()
                 
                     return group.remove(md)
@@ -86,20 +84,16 @@ class ObservableCoincidence(Observable, metaclass=ObservableMeta):
                     observer.on_next(result)
                 
             def on_completed_left():
-                nonlocal left_done
-
-                left_done = True
-                if right_done or not len(left_map):
+                left_done[0] = True
+                if right_done[0] or not len(left_map):
                     observer.on_completed()
                 
             group.add(left.subscribe(on_next_left, observer.on_error, on_completed_left))
 
             def on_next_right(value):
-                nonlocal right_id
-
                 duration = None
-                current_id = right_id
-                right_id += 1
+                current_id = right_id[0]
+                right_id[0] += 1
                 md = SingleAssignmentDisposable()
                 right_map[current_id] = value
                 group.add(md)
@@ -107,7 +101,7 @@ class ObservableCoincidence(Observable, metaclass=ObservableMeta):
                 def expire():
                     if current_id in right_map:
                         del right_map[current_id]
-                    if not len(right_map) and right_done:
+                    if not len(right_map) and right_done[0]:
                         observer.on_completed()
                         
                     return group.remove(md)
@@ -132,10 +126,8 @@ class ObservableCoincidence(Observable, metaclass=ObservableMeta):
                     observer.on_next(result)
                 
             def on_completed_right():
-                nonlocal right_done
-
-                right_done = True
-                if left_done or not len(right_map):
+                right_done[0] = True
+                if left_done[0] or not len(right_map):
                     observer.on_completed()
                 
             group.add(right.subscribe(on_next_right, observer.on_error, on_completed_right))

--- a/rx/linq/observable_concurrency.py
+++ b/rx/linq/observable_concurrency.py
@@ -1,9 +1,11 @@
+from six import add_metaclass
 from rx import AnonymousObservable, Observable
 from rx.observable import ObservableMeta
 from rx.observeonobserver import ObserveOnObserver
 from rx.disposables import SingleAssignmentDisposable, SerialDisposable, ScheduledDisposable
 
-class ObservableConcurrency(Observable, metaclass=ObservableMeta):
+@add_metaclass(ObservableMeta)
+class ObservableConcurrency(Observable):
     def observe_on(self, scheduler):
         """Wraps the source sequence in order to run its observer callbacks on 
         the specified scheduler.

--- a/rx/linq/observable_creation.py
+++ b/rx/linq/observable_creation.py
@@ -1,10 +1,12 @@
+from six import add_metaclass
 from rx.observable import Observable, ObservableMeta
 from rx.anonymousobservable import AnonymousObservable
 
 from rx.disposables import Disposable, CompositeDisposable
 from rx.concurrency import immediate_scheduler, current_thread_scheduler
 
-class ObservableCreation(Observable, metaclass=ObservableMeta):
+@add_metaclass(ObservableMeta)
+class ObservableCreation(Observable):
 
     @classmethod
     def create(cls, subscribe):

--- a/rx/linq/observable_creation.py
+++ b/rx/linq/observable_creation.py
@@ -81,14 +81,12 @@ class ObservableCreation(Observable, metaclass=ObservableMeta):
         scheduler = scheduler or current_thread_scheduler
 
         def subscribe(observer):
-            count = 0
+            count = [0]
             
             def action(action1, state=None):
-                nonlocal count
-                
-                if count < len(array):
-                    observer.on_next(array[count])
-                    count += 1
+                if count[0] < len(array):
+                    observer.on_next(array[count[0]])
+                    count[0] += 1
                     action1(action)
                 else:
                     observer.on_completed()
@@ -119,23 +117,22 @@ class ObservableCreation(Observable, metaclass=ObservableMeta):
         scheduler = scheduler or current_thread_scheduler
 
         def subscribe(observer):
-            first = True
-            state = initial_state
+            first = [True]
+            state = [initial_state]
             
             def action (action1, state1=None):
-                nonlocal first, state
                 has_result = False
                 result = None
 
                 try:
-                    if first:
-                        first = False
+                    if first[0]:
+                        first[0] = False
                     else:
-                        state = iterate(state)
+                        state[0] = iterate(state[0])
                     
-                    has_result = condition(state)
+                    has_result = condition(state[0])
                     if has_result:
-                        result = result_selector(state)
+                        result = result_selector(state[0])
                     
                 except Exception as exception:
                     observer.on_error(exception)

--- a/rx/linq/observable_leave.py
+++ b/rx/linq/observable_leave.py
@@ -9,19 +9,18 @@ class ObservableLeave(Observable, metaclass=ObservableMeta):
         source = self
 
         def subscribe(observer):
-            has_value = False
-            value = None
+            has_value = [False]
+            value = [None]
 
             def on_next(x):
-                nonlocal has_value, value
-                has_value = True
-                value = x
+                has_value[0] = True
+                value[0] = x
             
             def on_completed():
-                if not has_value:
+                if not has_value[0]:
                     observer.on_error(SequenceContainsNoElementsError())
                 else:
-                    observer.on_next(value)
+                    observer.on_next(value[0])
                     observer.on_completed()
     
             return source.subscribe(on_next, observer.on_error, on_completed)

--- a/rx/linq/observable_leave.py
+++ b/rx/linq/observable_leave.py
@@ -1,9 +1,11 @@
+from six import add_metaclass
 from rx.concurrency import Scheduler
 from rx.observable import Observable, ObservableMeta
 from rx.anonymousobservable import AnonymousObservable
 from rx.internal import SequenceContainsNoElementsError
 
-class ObservableLeave(Observable, metaclass=ObservableMeta):
+@add_metaclass(ObservableMeta)
+class ObservableLeave(Observable):
 
     def final_value(self):
         source = self

--- a/rx/linq/observable_multiple.py
+++ b/rx/linq/observable_multiple.py
@@ -1,13 +1,14 @@
+from six import add_metaclass
 
 from rx.internal import Enumerable, noop
 from rx.observable import Observable, ObservableMeta
 from rx.anonymousobservable import AnonymousObservable
 from rx.disposables import Disposable, CompositeDisposable, SingleAssignmentDisposable, SerialDisposable
 from rx.concurrency import immediate_scheduler
-
 from .observable_single import concat, catch_exception
 
-class ObservableMultiple(Observable, metaclass=ObservableMeta):
+@add_metaclass(ObservableMeta)
+class ObservableMultiple(Observable):
     def __init__(self, subscribe):
         self.concat = self.__concat # Stitch in instance method
         self.merge = self.__merge

--- a/rx/linq/observable_single.py
+++ b/rx/linq/observable_single.py
@@ -1,4 +1,4 @@
-from six import add_metaclass
+import six
 from rx.concurrency import Scheduler
 from rx.observable import Observable, ObservableMeta
 from rx.anonymousobservable import AnonymousObservable
@@ -21,7 +21,7 @@ def concat(sources):
             if is_disposed[0]:
                 return
             try:
-                current = next(e)
+                current = six.next(e)
             except StopIteration:
                 observer.on_completed()    
             except Exception as ex:
@@ -59,7 +59,7 @@ def catch_exception(sources):
             if is_disposed[0]:
                 return
             try:
-                current = next(e)
+                current = six.next(e)
             except StopIteration:
                 if last_exception[0]:
                     observer.on_error(last_exception[0])
@@ -85,7 +85,7 @@ def catch_exception(sources):
     return AnonymousObservable(subscribe)
 
 
-@add_metaclass(ObservableMeta)
+@six.add_metaclass(ObservableMeta)
 class ObservableSingle(Observable):
     
     def __init__(self, subscribe):

--- a/rx/linq/observable_single.py
+++ b/rx/linq/observable_single.py
@@ -1,3 +1,4 @@
+from six import add_metaclass
 from rx.concurrency import Scheduler
 from rx.observable import Observable, ObservableMeta
 from rx.anonymousobservable import AnonymousObservable
@@ -84,7 +85,8 @@ def catch_exception(sources):
     return AnonymousObservable(subscribe)
 
 
-class ObservableSingle(Observable, metaclass=ObservableMeta):
+@add_metaclass(ObservableMeta)
+class ObservableSingle(Observable):
     
     def __init__(self, subscribe):
         self.repeat = self.__repeat # Stitch in instance method

--- a/rx/linq/observable_time.py
+++ b/rx/linq/observable_time.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timedelta
+from six import add_metaclass
 
 from rx.internal.utils import add_ref
 from rx.observable import Observable, ObservableMeta
@@ -35,7 +36,8 @@ class Timestamp(object):
     #def equals(other):
     #    return other.timestamp == self.timestamp and other.value == self.value
 
-class ObservableTime(Observable, metaclass=ObservableMeta):
+@add_metaclass(ObservableMeta)
+class ObservableTime(Observable):
 
     @classmethod
     def observable_timer_timespan_and_period(cls, duetime, period, scheduler):

--- a/rx/linq/standardsequenceoperators.py
+++ b/rx/linq/standardsequenceoperators.py
@@ -1,6 +1,6 @@
 import types
 from inspect import getargspec, getargvalues 
-from six import add_metaclass
+import six
 
 from rx import Observable, AnonymousObservable
 from rx.subjects import Subject
@@ -23,7 +23,7 @@ def adapt_call(func):
     
     return func_wrapped
 
-@add_metaclass(ObservableMeta)
+@six.add_metaclass(ObservableMeta)
 class ObservableLinq(Observable):
     """Standard sequence operator extension methods. Note that we do some magic
     here by using a meta class to extend Observable with the methods in this
@@ -132,7 +132,7 @@ class ObservableLinq(Observable):
                 try:
                     key = key_selector(x)
                 except Exception as e:
-                    for w in mapping.values():
+                    for w in six.itervalues(mapping):
                         w.on_error(e)
                     
                     observer.on_error(e)
@@ -149,7 +149,7 @@ class ObservableLinq(Observable):
                         fire_new_map_entry = True
                     
                 except Exception as e:
-                    for w in mapping.values():
+                    for w in six.itervalues(mapping):
                         w.on_error(e)
                     
                     observer.on_error(e)
@@ -161,7 +161,7 @@ class ObservableLinq(Observable):
                     try:
                         duration = duration_selector(duration_group)
                     except Exception as e:
-                        for w in mapping.values():
+                        for w in six.itervalues(mapping):
                             w.on_error(e)
                         
                         observer.on_error(e)
@@ -183,7 +183,7 @@ class ObservableLinq(Observable):
 
                     def on_error(exn):
                         print ("on_error()", exn)
-                        for wr in mapping.values():
+                        for wr in six.itervalues(mapping):
                             wr.on_error(exn)
                         observer.on_error(exn)
 
@@ -195,7 +195,7 @@ class ObservableLinq(Observable):
                 try:
                     element = element_selector(x)
                 except Exception as e:
-                    for w in mapping.values():
+                    for w in six.itervalues(mapping):
                         w.on_error(e)
                     
                     observer.on_error(e)
@@ -205,13 +205,13 @@ class ObservableLinq(Observable):
             
             def on_error(ex):
                 print ("on_error(%s)" % ex)
-                for w in mapping.values():
+                for w in six.itervalues(mapping):
                     w.on_error(ex)
                 
                 observer.on_error(ex)
             
             def on_completed():
-                for w in mapping.values():
+                for w in six.itervalues(mapping):
                     w.on_completed()
                 
                 observer.on_completed()

--- a/rx/linq/standardsequenceoperators.py
+++ b/rx/linq/standardsequenceoperators.py
@@ -47,17 +47,16 @@ class ObservableLinq(Observable, metaclass=ObservableMeta):
         selector = adapt_call(selector)        
 
         def subscribe(observer):
-            count = 0
+            count = [0]
 
             def on_next(value):
-                nonlocal count
                 result = None
                 try:
-                    result = selector(value, count)
+                    result = selector(value, count[0])
                 except Exception as err:
                     observer.on_error(err)
                 else:
-                    count += 1
+                    count[0] += 1
                     observer.on_next(result)
 
             return self.subscribe(on_next, observer.on_error, observer.on_completed)
@@ -288,15 +287,13 @@ class ObservableLinq(Observable, metaclass=ObservableMeta):
         observable = self
 
         def subscribe(observer):
-            remaining = count
+            remaining = [count]
 
             def on_next(value):
-                nonlocal remaining
-
-                if remaining <= 0:
+                if remaining[0] <= 0:
                     observer.on_next(value)
                 else:
-                    remaining -= 1
+                    remaining[0] -= 1
                 
             return observable.subscribe(on_next, observer.on_error, observer.on_completed)
         return AnonymousObservable(subscribe)
@@ -321,20 +318,19 @@ class ObservableLinq(Observable, metaclass=ObservableMeta):
         source = self
 
         def subscribe(observer):
-            i, running = 0, False
+            i, running = [0], [False]
 
             def on_next(value):
-                nonlocal running, i
-                if not running:
+                if not running[0]:
                     try:
-                        running = not predicate(value, i)
+                        running[0] = not predicate(value, i[0])
                     except Exception as exn:
                         observer.on_error(exn)
                         return
                     else:
-                        i += 1
+                        i[0] += 1
         
-                if running:
+                if running[0]:
                     observer.on_next(value)
                 
             return source.subscribe(on_next, observer.on_error, observer.on_completed)
@@ -365,15 +361,13 @@ class ObservableLinq(Observable, metaclass=ObservableMeta):
         
         observable = self
         def subscribe(observer):
-            remaining = count
+            remaining = [count]
 
             def on_next(value):
-                nonlocal remaining
-
-                if remaining > 0:
-                    remaining -= 1
+                if remaining[0] > 0:
+                    remaining[0] -= 1
                     observer.on_next(value)
-                    if not remaining:
+                    if not remaining[0]:
                         observer.on_completed()
                     
             return observable.subscribe(on_next, observer.on_error, observer.on_completed)
@@ -399,20 +393,19 @@ class ObservableLinq(Observable, metaclass=ObservableMeta):
         predicate = adapt_call(predicate)
         observable = self
         def subscribe(observer):
-            running, i = True, 0
+            running, i = [True], [0]
 
             def on_next(value):
-                nonlocal running, i
-                if running:
+                if running[0]:
                     try:
-                        running = predicate(value, i)
+                        running[0] = predicate(value, i[0])
                     except Exception as exn:
                         observer.on_error(exn)
                         return
                     else:
-                        i += 1
+                        i[0] += 1
                     
-                    if running:
+                    if running[0]:
                         observer.on_next(value)
                     else:
                         observer.on_completed()
@@ -439,18 +432,17 @@ class ObservableLinq(Observable, metaclass=ObservableMeta):
         parent = self
         
         def subscribe(observer):
-            count = 0
+            count = [0]
 
             def on_next(value):
-                nonlocal count
                 should_run = False
                 try:
-                    should_run = predicate(value, count)
+                    should_run = predicate(value, count[0])
                 except Exception as ex:
                     observer.on_error(ex)
                     return
                 else:
-                    count += 1
+                    count[0] += 1
                 
                 if should_run:
                     observer.on_next(value)

--- a/rx/linq/standardsequenceoperators.py
+++ b/rx/linq/standardsequenceoperators.py
@@ -1,5 +1,6 @@
 import types
 from inspect import getargspec, getargvalues 
+from six import add_metaclass
 
 from rx import Observable, AnonymousObservable
 from rx.subjects import Subject
@@ -21,8 +22,9 @@ def adapt_call(func):
         func_wrapped = func1
     
     return func_wrapped
-        
-class ObservableLinq(Observable, metaclass=ObservableMeta):
+
+@add_metaclass(ObservableMeta)
+class ObservableLinq(Observable):
     """Standard sequence operator extension methods. Note that we do some magic
     here by using a meta class to extend Observable with the methods in this
     class"""

--- a/rx/observable.py
+++ b/rx/observable.py
@@ -1,10 +1,11 @@
+import six
 from .observer import Observer, AbstractObserver
 
 class ObservableMeta(type):
     def __new__(cls, name, bases, namespace):
         assert len(bases) == 1, "Exactly one base class required"
         base = bases[0]
-        for name, value in namespace.items():
+        for name, value in six.iteritems(namespace):
             if name == "__init__":
                 base.initializers.append(value)
 

--- a/rx/testing/reactive_assert.py
+++ b/rx/testing/reactive_assert.py
@@ -1,4 +1,5 @@
 import sys, traceback
+import types
 
 from rx import Observable, AnonymousObservable
 
@@ -35,22 +36,22 @@ class AssertList(list):
         expected = list(expected)
         return are_elements_equal(expected, self, default_comparer)
 
-class ObservableTest(object):
-    # Observable.dump extension method
-    def dump(self, name = "test"):
-        def subscribe(observer):
-            def on_next(value):
-                print("{%s}-->{%s}" % (name, value))
-                observer.on_next(value)
-            def on_error(ex):
-                print("{%s} error -->{%s}" % (name, ex))    
-                traceback.print_exc(file=sys.stdout)
-                observer.on_error(ex)
-            def on_completed():
-                print("{%s} completed" % name)
-                observer.on_completed()
 
-            return self.subscribe(on_next, on_error, on_completed)
-        return AnonymousObservable(subscribe)
+# Observable.dump extension method
+def dump(self, name = "test"):
+    def subscribe(observer):
+        def on_next(value):
+            print("{%s}-->{%s}" % (name, value))
+            observer.on_next(value)
+        def on_error(ex):
+            print("{%s} error -->{%s}" % (name, ex))
+            traceback.print_exc(file=sys.stdout)
+            observer.on_error(ex)
+        def on_completed():
+            print("{%s} completed" % name)
+            observer.on_completed()
 
-Observable.dump = ObservableTest.dump
+        return self.subscribe(on_next, on_error, on_completed)
+    return AnonymousObservable(subscribe)
+
+Observable.dump = dump

--- a/rx/testing/reactivetest.py
+++ b/rx/testing/reactivetest.py
@@ -9,7 +9,7 @@ def is_prime(i):
     if i <= 1:
         return False
     
-    max = math.floor(math.sqrt(i))
+    max = int(math.floor(math.sqrt(i)))
     for j in range(2, max+1):
         if not (i % j):
             return False

--- a/rx/testing/testscheduler.py
+++ b/rx/testing/testscheduler.py
@@ -55,7 +55,7 @@ class TestScheduler(VirtualTimeScheduler):
         Returns corresponding DateTimeOffset value.
         """
             
-        return datetime.fromtimestamp(absolute/1000)
+        return datetime.fromtimestamp(absolute/1000.0)
     
     @classmethod
     def to_relative(cls, timespan):

--- a/rx/testing/testscheduler.py
+++ b/rx/testing/testscheduler.py
@@ -90,26 +90,24 @@ class TestScheduler(VirtualTimeScheduler):
         disposed= disposed or ReactiveTest.disposed
         
         observer = self.create_observer()
-        subscription = None
-        source = None
+        subscription = [None]
+        source = [None]
 
         def action_create(scheduler, state):
             """Called at create time. Defaults to 100"""
-            nonlocal source
-            source = create()
+            source[0] = create()
             return Disposable.empty()
         self.schedule_absolute(created, action_create)
 
         def action_subscribe(scheduler, state):
             """Called at subscribe time. Defaults to 200"""
-            nonlocal subscription
-            subscription = source.subscribe(observer)
+            subscription[0] = source[0].subscribe(observer)
             return Disposable.empty()
         self.schedule_absolute(subscribed, action_subscribe)
 
         def action_dispose(scheduler, state):
             """Called at dispose time. Defaults to 1000"""
-            subscription.dispose()
+            subscription[0].dispose()
             return Disposable.empty()
         self.schedule_absolute(disposed, action_dispose)
 

--- a/tests/test_asyncsubject.py
+++ b/tests/test_asyncsubject.py
@@ -22,11 +22,11 @@ def _raise(ex):
     raise RxException(ex)
 
 def test_infinite():
-    subject = None
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    subject = [None]
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
 
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(
@@ -48,48 +48,43 @@ def test_infinite():
     results3 = scheduler.create_observer()
     
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = AsyncSubject()
+        subject[0] = AsyncSubject()
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(subject)
+        subscription[0] = xs.subscribe(subject[0])
     scheduler.schedule_absolute(200, action2)
     
     def action3(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action3)
     
     def action4(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(300, action4)
     
     def action5(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(400, action5)
     
     def action6(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(900, action6)
     
     def action7(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action7)
     
     def action8(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action8)
     
     def action9(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action9)
     
     def action10(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action10)
 
     scheduler.start()
@@ -98,11 +93,11 @@ def test_infinite():
     results3.messages.assert_equal()
 
 def test_finite():
-    subject = None
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    subject = [None]
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
 
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(
@@ -123,48 +118,43 @@ def test_finite():
     results3 = scheduler.create_observer()
     
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = AsyncSubject()
+        subject[0] = AsyncSubject()
     scheduler.schedule_absolute(100, action1)
     
     def action2(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(subject)
+        subscription[0] = xs.subscribe(subject[0])
     scheduler.schedule_absolute(200, action2)
     
     def action3(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action3)
     
     def action4(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(300, action4)
     
     def action5(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(400, action5)
     
     def action6(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(900, action6)
     
     def action7(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action7)
     
     def action8(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action8)
     
     def action9(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action9)
     
     def action10(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action10)
     
     scheduler.start()
@@ -173,11 +163,11 @@ def test_finite():
     results3.messages.assert_equal(on_next(900, 7), on_completed(900))
 
 def test_error():
-    subject = None
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    subject = [None]
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
 
     ex = 'ex'
     scheduler = TestScheduler()
@@ -199,48 +189,43 @@ def test_error():
     results3 = scheduler.create_observer()
     
     def action(scheduler, state=None):
-        nonlocal subject
-        subject = AsyncSubject()
+        subject[0] = AsyncSubject()
     scheduler.schedule_absolute(100, action)
     
     def action1(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(subject)
+        subscription[0] = xs.subscribe(subject[0])
     scheduler.schedule_absolute(200, action1)
     
     def action2(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action2)
     
     def action3(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(300, action3)
     
     def action4(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(400, action4)
     
     def action5(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(900, action5)
     
     def action6(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action6)
     
     def action7(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action7)
     
     def action8(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action8)
     
     def action9(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action9)
     
     scheduler.start()
@@ -249,11 +234,11 @@ def test_error():
     results3.messages.assert_equal(on_error(900, ex))
 
 def test_canceled():
-    subject = None
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    subject = [None]
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
 
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(
@@ -268,48 +253,43 @@ def test_canceled():
     results3 = scheduler.create_observer()
     
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = AsyncSubject()
+        subject[0] = AsyncSubject()
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(subject)
+        subscription[0] = xs.subscribe(subject[0])
     scheduler.schedule_absolute(200, action2)
     
     def action3(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action3)
     
     def action4(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(300, action4)
     
     def action5(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(400, action5)
     
     def action6(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(900, action6)
     
     def action7(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action7)
     
     def action8(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action8)
     
     def action9(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action9)
     
     def action10(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action10)
     
     scheduler.start()
@@ -318,10 +298,10 @@ def test_canceled():
     results3.messages.assert_equal(on_completed(900))
 
 def test_subject_disposed():
-    subject = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    subject = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
     scheduler = TestScheduler()
 
     results1 = scheduler.create_observer()
@@ -329,79 +309,75 @@ def test_subject_disposed():
     results3 = scheduler.create_observer()
     
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = AsyncSubject()
+        subject[0] = AsyncSubject()
     scheduler.schedule_absolute(100, action1)
     
     def action2(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(200, action2)
     
     def action3(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(300, action3)
     
     def action4(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(400, action4)
     
     def action5(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(500, action5)
     
     def action6(scheduler, state=None):
-        subject.dispose()
+        subject[0].dispose()
     scheduler.schedule_absolute(600, action6)
     
     def action7(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action7)
     
     def action8(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(800, action8)
     
     def action9(scheduler, state=None):
-        subject.on_next(1)
+        subject[0].on_next(1)
     scheduler.schedule_absolute(150, action9)
     
     def action10(scheduler, state=None):
-        subject.on_next(2)
+        subject[0].on_next(2)
     scheduler.schedule_absolute(250, action10)
     
     def action11(scheduler, state=None):
-        subject.on_next(3)
+        subject[0].on_next(3)
     scheduler.schedule_absolute(350, action11)
     
     def action12(scheduler, state=None):
-        subject.on_next(4)
+        subject[0].on_next(4)
     scheduler.schedule_absolute(450, action12)
     
     def action13(scheduler, state=None):
-        subject.on_next(5)
+        subject[0].on_next(5)
     scheduler.schedule_absolute(550, action13)
     
     @raises(DisposedException)
     def action14(scheduler, state=None):
-        subject.on_next(6)
+        subject[0].on_next(6)
     scheduler.schedule_absolute(650, action14)
     
     @raises(DisposedException)
     def action15(scheduler, state=None):
-        subject.on_completed()
+        subject[0].on_completed()
     scheduler.schedule_absolute(750, action15)
     
     @raises(DisposedException)
     def action16(scheduler, state=None):
-        subject.on_error('ex')
+        subject[0].on_error('ex')
     scheduler.schedule_absolute(850, action16)
     
     @raises(DisposedException)
     def action17(scheduler, state=None):
-        subject.subscribe(None)
+        subject[0].subscribe(None)
     scheduler.schedule_absolute(950, action17)
      
     scheduler.start()

--- a/tests/test_behaviorsubject.py
+++ b/tests/test_behaviorsubject.py
@@ -39,59 +39,54 @@ def test_infinite():
         on_next(1020, 12)
     )
 
-    subject = None
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    subject = [None]
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = BehaviorSubject(100)
+        subject[0] = BehaviorSubject(100)
     scheduler.schedule_absolute(100, action1)
     
     def action2(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(subject)
+        subscription[0] = xs.subscribe(subject[0])
     scheduler.schedule_absolute(200, action2) 
     
     def action3(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action3)
     
     def action4(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(300, action4)
 
     def action5(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(400, action5)
 
     def action6(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(900, action6)
     
     def action7(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action7)
     
     def action8(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action8)
     
     def action9(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action9)
     
     def action10(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action10)
     
     scheduler.start()
@@ -132,59 +127,54 @@ def test_finite():
         on_error(660, RxException())
     )
 
-    subject = None
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    subject = [None]
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = BehaviorSubject(100)
+        subject[0] = BehaviorSubject(100)
     scheduler.schedule_absolute(100, action1)
     
     def action2(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(subject)
+        subscription[0] = xs.subscribe(subject[0])
     scheduler.schedule_absolute(200, action2) 
     
     def action3(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action3) 
     
     def action4(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(300, action4)
     
     def action5(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(400, action5)
     
     def action6(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(900, action6)
     
     def action7(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action7)
     
     def action8(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action8)
     
     def action9(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action9)
     
     def action10(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action10)
 
     scheduler.start()
@@ -226,59 +216,54 @@ def test_error():
         on_error(660, RxException())
     )
 
-    subject = None
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    subject = [None]
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = BehaviorSubject(100)
+        subject[0] = BehaviorSubject(100)
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(subject)
+        subscription[0] = xs.subscribe(subject[0])
     scheduler.schedule_absolute(200, action2)
     
     def action3(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action3)
     
     def action4(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(300, action4)
 
     def action5(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(400, action5)
 
     def action6(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(900, action6)
     
     def action7(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action7)
     
     def action8(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action8)
 
     def action9(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action9)
     
     def action10(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action10)
     
     scheduler.start()
@@ -311,59 +296,54 @@ def test_canceled():
         on_error(660, RxException())
     )
 
-    subject = None
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    subject = [None]
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = BehaviorSubject(100)
+        subject[0] = BehaviorSubject(100)
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(subject)
+        subscription[0] = xs.subscribe(subject[0])
     scheduler.schedule_absolute(200, action2)
 
     def action3(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action3)
 
     def action4(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(300, action4)
 
     def action5(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(400, action5)
 
     def action6(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(900, action6)
 
     def action7(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action7)
 
     def action8(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action8)
 
     def action9(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action9)
 
     def action10(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action10)
 
     scheduler.start()
@@ -384,91 +364,87 @@ def test_canceled():
 def test_subject_disposed():
     scheduler = TestScheduler()
 
-    subject = None
+    subject = [None]
 
     results1 = scheduler.create_observer()
-    subscription1 = None
+    subscription1 = [None]
 
     results2 = scheduler.create_observer()
-    subscription2 = None
+    subscription2 = [None]
 
     results3 = scheduler.create_observer()
-    subscription3 = None
+    subscription3 = [None]
 
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = BehaviorSubject(0)
+        subject[0] = BehaviorSubject(0)
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(200, action2)
     
     def action3(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(300, action3)
     
     def action4(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(400, action4)
     
     def action5(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(500, action5)
     
     def action6(scheduler, state=None):
-        subject.dispose()
+        subject[0].dispose()
     scheduler.schedule_absolute(600, action6)
     
     def action7(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action7)
     
     def action8(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(800, action8)
     
     def action9(scheduler, state=None):
-        subject.on_next(1)
+        subject[0].on_next(1)
     scheduler.schedule_absolute(150, action9)
     
     def action10(scheduler, state=None):
-        subject.on_next(2)
+        subject[0].on_next(2)
     scheduler.schedule_absolute(250, action10)
     
     def action11(scheduler, state=None):
-        subject.on_next(3)
+        subject[0].on_next(3)
     scheduler.schedule_absolute(350, action11)
     
     def action12(scheduler, state=None):
-        subject.on_next(4)
+        subject[0].on_next(4)
     scheduler.schedule_absolute(450, action12)
     
     def action13(scheduler, state=None):
-        subject.on_next(5)
+        subject[0].on_next(5)
     scheduler.schedule_absolute(550, action13)
     
     @raises(DisposedException)
     def action14(scheduler, state=None):
-        subject.on_next(6)
+        subject[0].on_next(6)
     scheduler.schedule_absolute(650, action14)
     
     @raises(DisposedException)
     def action15(scheduler, state=None):
-        subject.on_completed()
+        subject[0].on_completed()
     scheduler.schedule_absolute(750, action15)
     
     @raises(DisposedException)
     def action16(scheduler, state=None):
-        subject.on_error(RxException())
+        subject[0].on_error(RxException())
     scheduler.schedule_absolute(850, action16)
 
     @raises(DisposedException)
     def action17(scheduler, state=None):
-        subject.subscribe(None)
+        subject[0].subscribe(None)
     scheduler.schedule_absolute(950, action17)
 
     scheduler.start()

--- a/tests/test_currentthreadscheduler.py
+++ b/tests/test_currentthreadscheduler.py
@@ -8,14 +8,13 @@ def test_currentthread_now():
 
 def test_currentthread_scheduleaction():
     scheduler = CurrentThreadScheduler()
-    ran = False
+    ran = [False]
 
     def action(scheduler, state=None):
-        nonlocal ran
-        ran = True
+        ran[0] = True
 
     scheduler.schedule(action)
-    assert ran == True
+    assert ran[0] == True
 
 def test_currentthread_scheduleactionerror():
     scheduler = CurrentThreadScheduler()
@@ -33,72 +32,65 @@ def test_currentthread_scheduleactionerror():
 
 def test_currentthread_scheduleactionnested():
     scheduler = CurrentThreadScheduler()
-    ran = False
+    ran = [False]
     
     def action(scheduler, state=None):
         def inner_action(scheduler, state=None):
-            nonlocal ran
-            ran = True
+            ran[0] = True
 
         return scheduler.schedule(inner_action)
     scheduler.schedule(action)
     
-    assert ran == True
+    assert ran[0] == True
 
 def test_currentthread_ensuretrampoline():
     scheduler = CurrentThreadScheduler()
-    ran1, ran2 = False, False
+    ran1, ran2 = [False], [False]
     
     def outer_action(scheduer, state=None):
         def action1(scheduler, state=None):
-            nonlocal ran1
-            ran1 = True
+            ran1[0] = True
 
         scheduler.schedule(action1)
 
         def action2(scheduler, state=None):
-            nonlocal ran2
-            ran2 = True
+            ran2[0] = True
 
         return scheduler.schedule(action2)
 
     scheduler.ensure_trampoline(outer_action)
-    assert ran1 == True
-    assert ran2 == True
+    assert ran1[0] == True
+    assert ran2[0] == True
 
 def test_currentthread_ensuretrampoline_nested():
     scheduler = CurrentThreadScheduler()
-    ran1, ran2 = False, False
+    ran1, ran2 = [False], [False]
 
     def outer_action(scheduler, state):
         def inner_action1(scheduler, state):
-            nonlocal ran1
-            ran1 = True
+            ran1[0] = True
         
         scheduler.ensure_trampoline(inner_action1)
         
         def inner_action2(scheduler, state):
-            nonlocal ran2
-            ran2 = True
+            ran2[0] = True
         
         return scheduler.ensure_trampoline(inner_action2)
 
     scheduler.ensure_trampoline(outer_action)
-    assert ran1 == True
-    assert ran2 == True
+    assert ran1[0] == True
+    assert ran2[0] == True
 
 def test_currentthread_ensuretrampoline_and_cancel():
     scheduler = CurrentThreadScheduler()
-    ran1, ran2 = False, False
+    ran1, ran2 = [False], [False]
 
     def outer_action(scheduler, state):
         def inner_action1(scheduler, state):
-            nonlocal ran1
-            ran1 = True
+            ran1[0] = True
 
             def inner_action2(scheduler, state):
-                nonlocal ran2
-                ran2 = True
+                ran2[0] = True
 
             d = scheduler.schedule(inner_action2)
             d.dispose()
@@ -106,21 +98,19 @@ def test_currentthread_ensuretrampoline_and_cancel():
         return scheduler.schedule(inner_action1)
 
     scheduler.ensure_trampoline(outer_action)
-    assert ran1 == True
-    assert ran2 == False
+    assert ran1[0] == True
+    assert ran2[0] == False
 
 def test_currentthread_ensuretrampoline_and_canceltimed():
     scheduler = CurrentThreadScheduler()
-    ran1, ran2 = False, False
+    ran1, ran2 = [False], [False]
     
     def outer_action(scheduler, state):
         def inner_action1(scheduler, state):
-            nonlocal ran1
-            ran1 = True
+            ran1[0] = True
 
             def inner_action2(scheduler, state):
-                nonlocal ran2
-                ran2 = True
+                ran2[0] = True
 
             d = scheduler.schedule_relative(timedelta(milliseconds=500), inner_action2)
             d.dispose()
@@ -128,5 +118,5 @@ def test_currentthread_ensuretrampoline_and_canceltimed():
         return scheduler.schedule(inner_action1)
 
     scheduler.ensure_trampoline(outer_action)
-    assert ran1 == True
-    assert ran2 == False
+    assert ran1[0] == True
+    assert ran2[0] == False

--- a/tests/test_disposable.py
+++ b/tests/test_disposable.py
@@ -17,16 +17,15 @@ def test_anonymousdisposable_create():
     assert disposable
 
 def test_anonymousdisposable_dispose():
-    disposed = False
+    disposed = [False]
     
     def action():
-        nonlocal disposed
-        disposed = True
+        disposed[0] = True
 
     d = Disposable(action)
-    assert not disposed
+    assert not disposed[0]
     d.dispose()
-    assert disposed
+    assert disposed[0]
 
 def test_emptydisposable():
     d = Disposable.empty()
@@ -48,40 +47,38 @@ def test_future_disposable_setnone():
 
 def test_futuredisposable_disposeafterset():
     d = SingleAssignmentDisposable()
-    disposed = False
+    disposed = [False]
     
     def action():
-        nonlocal disposed
-        disposed = True
+        disposed[0] = True
 
     dd = Disposable(action)
     d.disposable = dd
     assert dd == d.disposable
-    assert not disposed
+    assert not disposed[0]
     
     d.dispose()
-    assert disposed
+    assert disposed[0]
     d.dispose()
-    assert disposed
+    assert disposed[0]
 
 def test_futuredisposable_disposebeforeset():
-    disposed = False
+    disposed = [False]
 
     def dispose():
-        nonlocal disposed
-        disposed = True
+        disposed[0] = True
     
     d = SingleAssignmentDisposable()
     dd = Disposable(dispose)
     
-    assert not disposed
+    assert not disposed[0]
     d.dispose()
-    assert not disposed
+    assert not disposed[0]
     d.disposable = dd
     assert d.disposable == None
-    assert disposed
+    assert disposed[0]
     d.dispose()
-    assert disposed
+    assert disposed[0]
 
 def test_groupdisposable_contains():
     d1 = Disposable.empty()
@@ -106,42 +103,38 @@ def test_groupdisposable_add():
     assert g.contains(d2)
 
 def test_groupdisposable_addafterdispose():
-    disp1 = False
-    disp2 = False
+    disp1 = [False]
+    disp2 = [False]
 
     def action1():
-        nonlocal disp1
-        disp1 = True
+        disp1[0] = True
 
     d1 = Disposable(action1)
 
     def action2():
-        nonlocal disp2
-        disp2 = True
+        disp2[0] = True
 
     d2 = Disposable(action2)
 
     g = CompositeDisposable(d1)
     assert g.length == 1
     g.dispose()
-    assert disp1
+    assert disp1[0]
     assert g.length == 0
     g.add(d2)
-    assert disp2
+    assert disp2[0]
     assert g.length == 0
 
 def test_groupdisposable_remove():
-    disp1 = False
-    disp2 = False
+    disp1 = [False]
+    disp2 = [False]
     
     def action1():
-        nonlocal disp1
-        disp1 = True
+        disp1[0] = True
     d1 = Disposable(action1)
 
     def action2():
-        nonlocal disp2
-        disp2 = True
+        disp2[0] = True
     d2 = Disposable(action2)
 
     g = CompositeDisposable(d1, d2)
@@ -153,49 +146,45 @@ def test_groupdisposable_remove():
     assert g.length == 1
     assert not g.contains(d1)
     assert g.contains(d2)
-    assert disp1
+    assert disp1[0]
     assert g.remove(d2)
     assert not g.contains(d1)
     assert not g.contains(d2)
-    assert disp2
+    assert disp2[0]
 
-    disp3 = False;
+    disp3 = [False]
 
     def action3():
-        nonlocal disp3
-        disp3 = True
+        disp3[0] = True
     d3 = Disposable(action3)
     assert not g.remove(d3)
-    assert not disp3
+    assert not disp3[0]
 
 def test_groupdisposable_clear():
-    disp1 = False
-    disp2 = False
+    disp1 = [False]
+    disp2 = [False]
     def action1():
-        nonlocal disp1
-        disp1 = True
+        disp1[0] = True
     d1 = Disposable(action1)
 
     def action2():
-        nonlocal disp2
-        disp2 = True
+        disp2[0] = True
     d2 = Disposable(action2)
 
     g = CompositeDisposable(d1, d2)
     assert g.length == 2
 
     g.clear()
-    assert disp1
-    assert disp2
+    assert disp1[0]
+    assert disp2[0]
     assert not g.length
 
-    disp3 = False
+    disp3 = [False]
     def action3():
-        nonlocal disp3
-        disp3 = True
+        disp3[0] = True
     d3 = Disposable(action3)
     g.add(d3);
-    assert not disp3
+    assert not disp3[0]
     assert g.length == 1
 
 def test_mutabledisposable_ctor_prop():
@@ -203,67 +192,62 @@ def test_mutabledisposable_ctor_prop():
     assert not m.disposable
 
 def test_mutabledisposable_replacebeforedispose():
-    disp1 = False
-    disp2 = False
+    disp1 = [False]
+    disp2 = [False]
     m = SerialDisposable()
 
     def action1():
-        nonlocal disp1
-        disp1 = True
+        disp1[0] = True
     d1 = Disposable(action1)
     m.disposable = d1
 
     assert d1 == m.disposable
-    assert not disp1
+    assert not disp1[0]
 
     def action2():
-        nonlocal disp2
-        disp2 = True
+        disp2[0] = True
     d2 = Disposable(action2)
     m.disposable = d2
 
     assert d2 == m.disposable
-    assert disp1
-    assert not disp2
+    assert disp1[0]
+    assert not disp2[0]
 
 def test_mutabledisposable_replaceafterdispose():
-    disp1 = False
-    disp2 = False
+    disp1 = [False]
+    disp2 = [False]
     m = SerialDisposable()
     m.dispose()
 
     def action1():
-        nonlocal disp1
-        disp1 = True
+        disp1[0] = True
     d1 = Disposable(action1)
     m.disposable = d1
 
     assert m.disposable == None
-    assert disp1
+    assert disp1[0]
 
     def action2():
-        nonlocal disp2
-        disp2 = True
+        disp2[0] = True
     d2 = Disposable(action2)
     m.disposable = d2
 
-    m.disposable == None
-    assert disp2
+    assert m.disposable == None
+    assert disp2[0]
 
 def test_mutabledisposable_dispose():
-    disp = False
+    disp = [False]
     m = SerialDisposable()
     
     def action():
-        nonlocal disp
-        disp = True
+        disp[0] = True
     d = Disposable(action)
     m.disposable = d
 
     assert d == m.disposable
-    assert not disp
+    assert not disp[0]
     m.dispose()
-    assert disp
+    assert disp[0]
     assert m.disposable == None
 
 def test_refcountdisposable_singlereference():

--- a/tests/test_immediatescheduler.py
+++ b/tests/test_immediatescheduler.py
@@ -9,14 +9,13 @@ def test_immediate_now():
 
 def test_immediate_scheduleaction():
     scheduler = ImmediateScheduler()
-    ran = False;
+    ran = [False]
 
     def action(scheduler, state=None):
-        nonlocal ran
-        ran = True
+        ran[0] = True
 
     scheduler.schedule(action)
-    assert ran
+    assert ran[0]
 
 def test_immediate_scheduleactionerror():
     scheduler = ImmediateScheduler()
@@ -34,94 +33,84 @@ def test_immediate_scheduleactionerror():
 
 def test_immediate_simple1():
     scheduler = ImmediateScheduler()
-    xx = 0
+    xx = [0]
 
     def action(scheduler, state=None):
-        nonlocal xx
-        xx = state
+        xx[0] = state
         return Disposable.empty()
 
     scheduler.schedule(action, 42)
-    assert xx == 42
+    assert xx[0] == 42
 
 def test_immediate_simple2():
     scheduler = ImmediateScheduler()
-    xx = 0
+    xx = [0]
     
     def action(scheduler, state=None):
-         nonlocal xx
-         xx = state
+         xx[0] = state
          return Disposable.empty()
 
-    scheduler.schedule_absolute(datetime.utcnow(), action, 42);
-    assert xx == 42
+    scheduler.schedule_absolute(datetime.utcnow(), action, 42)
+    assert xx[0] == 42
 
 def test_immediate_simple3():
     scheduler = ImmediateScheduler()
-    xx = 0
+    xx = [0]
     
     def action(scheduler, state=None):
-         nonlocal xx
-         xx = state
+         xx[0] = state
          return Disposable.empty()
 
-    scheduler.schedule_relative(timedelta(0), action, 42);
-    assert xx == 42
+    scheduler.schedule_relative(timedelta(0), action, 42)
+    assert xx[0] == 42
 
 def test_immediate_recursive1():
     scheduler = ImmediateScheduler()
-    xx = 0
-    yy = 0
+    xx = [0]
+    yy = [0]
     
     def action(scheduler, x=None):
-        nonlocal xx
-        
-        xx = x
+        xx[0] = x
         
         def inner_action(scheduler, y):
-            nonlocal yy
-            yy = y
+            yy[0] = y
             return Disposable.empty()
         
         return scheduler.schedule(inner_action, 43) 
 
     scheduler.schedule(action, 42)
-    assert xx == 42
-    assert yy == 43
+    assert xx[0] == 42
+    assert yy[0] == 43
 
 def test_immediate_recursive2():
     scheduler = ImmediateScheduler()
-    xx = 0
-    yy = 0
+    xx = [0]
+    yy = [0]
     
     def action(scheduler, state=None):
-        nonlocal xx
-        xx = state
+        xx[0] = state
         
         def inner_action(scheduler, state=None):
-            nonlocal yy
-            yy = state
+            yy[0] = state
             return Disposable.empty()
 
         return scheduler.schedule_absolute(datetime.utcnow(), inner_action, 43)
 
     scheduler.schedule_absolute(datetime.utcnow(), action, 42) 
 
-    assert xx == 42
-    assert yy == 43
+    assert xx[0] == 42
+    assert yy[0] == 43
 
 def test_immediate_recursive3():
     scheduler = ImmediateScheduler()
-    xx = 0
-    yy = 0
+    xx = [0]
+    yy = [0]
 
     def action(scheduler, state=None):
-        nonlocal xx
-        xx = state
+        xx[0] = state
 
         def inner_action(scheduler, state):
-            nonlocal yy
-            yy = state
+            yy[0] = state
             return Disposable.empty()
 
         return scheduler.schedule_relative(timedelta(0), inner_action, 43)
@@ -129,5 +118,5 @@ def test_immediate_recursive3():
     scheduler.schedule_relative(timedelta(0), action, 42) 
     
     
-    assert xx == 42
-    assert yy == 43
+    assert xx[0] == 42
+    assert yy[0] == 43

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -90,19 +90,18 @@ def test_on_next_accept_observer_with_result():
     assert('OK' == res)
 
 def test_on_next_accept_action():
-    obs = False
+    obs = [False]
     n1 = OnNext(42)
     def on_next(x):
-        nonlocal obs
-        obs = True
-        return obs
+        obs[0] = True
+        return obs[0]
     def on_error(err):
         assert(False)
     def on_completed():
         assert(False)
     n1.accept(on_next, on_error, on_completed)
         
-    assert(obs)
+    assert(obs[0])
 
 def test_on_next_accept_action_with_result():
     n1 = OnNext(42)
@@ -187,22 +186,21 @@ def test_on_error_accept_observer_with_result():
 
 def test_on_error_accept_action():
     ex = 'ex'
-    obs = False
+    obs = [False]
     n1 = OnError(ex)
 
     def on_next(x):
         assert(False)
         return None
     def on_error(ex):
-        nonlocal obs
-        obs = True
-        return obs
+        obs[0] = True
+        return obs[0]
     def on_completed():
         assert(False)
         return None
 
     n1.accept(on_next, on_error, on_completed)
-    assert(obs)
+    assert(obs[0])
 
 
 def test_on_error_accept_action_with_result():
@@ -279,7 +277,7 @@ def test_on_completed_accept_observer_with_result():
     assert('OK' == res)
 
 def test_on_completed_accept_action():
-    obs = False
+    obs = [False]
     n1 = OnCompleted()
 
     def on_next(x):
@@ -289,12 +287,11 @@ def test_on_completed_accept_action():
         assert(False)
         return None
     def on_completed():
-        nonlocal obs
-        obs = True
-        return obs
+        obs[0] = True
+        return obs[0]
 
     n1.accept(on_next, on_error, on_completed) 
-    assert(obs)
+    assert(obs[0])
 
 def test_on_completed_accept_action_with_result():
     n1 = OnCompleted()

--- a/tests/test_observable_multiple.py
+++ b/tests/test_observable_multiple.py
@@ -134,12 +134,10 @@ def test_take_until_preempt_beforefirstproduced_remain_silent_and_proper_dispose
     scheduler = TestScheduler()
     l_msgs = [on_next(150, 1), on_error(215, 'ex'), on_completed(240)]
     r_msgs = [on_next(150, 1), on_next(210, 2), on_completed(220)]
-    source_not_disposed = False
+    source_not_disposed = [False]
 
     def action():
-        nonlocal source_not_disposed
-
-        source_not_disposed = True
+        source_not_disposed[0] = True
     l = scheduler.create_hot_observable(l_msgs).do_action(on_next=action)
     
     r = scheduler.create_hot_observable(r_msgs)
@@ -150,18 +148,17 @@ def test_take_until_preempt_beforefirstproduced_remain_silent_and_proper_dispose
     results = scheduler.start(create)
     
     results.messages.assert_equal(on_completed(210))
-    assert(not source_not_disposed)
+    assert(not source_not_disposed[0])
 
 def test_take_until_nopreempt_afterlastproduced_proper_disposed_signal():
     scheduler = TestScheduler()
     l_msgs = [on_next(150, 1), on_next(230, 2), on_completed(240)]
     r_msgs = [on_next(150, 1), on_next(250, 2), on_completed(260)]
-    signal_not_disposed = False
+    signal_not_disposed = [False]
     l = scheduler.create_hot_observable(l_msgs)
 
     def action():
-        nonlocal signal_not_disposed
-        signal_not_disposed = True
+        signal_not_disposed[0] = True
     r = scheduler.create_hot_observable(r_msgs).do_action(on_next=action)
     
     def create():
@@ -169,7 +166,7 @@ def test_take_until_nopreempt_afterlastproduced_proper_disposed_signal():
     
     results = scheduler.start(create)        
     results.messages.assert_equal(on_next(230, 2), on_completed(240))
-    assert(not signal_not_disposed)
+    assert(not signal_not_disposed[0])
 
 def test_skip_until_somedata_next():
     scheduler = TestScheduler()
@@ -274,12 +271,11 @@ def test_skip_until_never_never():
 def test_skip_until_has_completed_causes_disposal():
     scheduler = TestScheduler()
     l_msgs = [on_next(150, 1), on_next(210, 2), on_next(220, 3), on_next(230, 4), on_next(240, 5), on_completed(250)]
-    disposed = False
+    disposed = [False]
     l = scheduler.create_hot_observable(l_msgs)
     
     def subscribe(observer):
-        nonlocal disposed
-        disposed = True
+        disposed[0] = True
     
     r = Observable(subscribe)
         
@@ -288,7 +284,7 @@ def test_skip_until_has_completed_causes_disposal():
     
     results = scheduler.start(create)
     results.messages.assert_equal()
-    assert(disposed)
+    assert(disposed[0])
 
 def test_merge_never2():
     scheduler = TestScheduler()
@@ -534,12 +530,11 @@ def test_merge_error_causes_disposal():
     scheduler = TestScheduler()
     msgs1 = [on_next(150, 1), on_error(210, ex)]
     msgs2 = [on_next(150, 1), on_next(220, 1), on_completed(250)]
-    source_not_disposed = False
+    source_not_disposed = [False]
     o1 = scheduler.create_hot_observable(msgs1)
     
     def action():
-        nonlocal source_not_disposed
-        source_not_disposed = True
+        source_not_disposed[0] = True
     
     o2 = scheduler.create_hot_observable(msgs2).do_action(on_next=action)
     
@@ -549,7 +544,7 @@ def test_merge_error_causes_disposal():
     results = scheduler.start(create)
     
     results.messages.assert_equal(on_error(210, ex))
-    assert(not source_not_disposed)
+    assert(not source_not_disposed[0])
 
 def test_merge_observable_of_observable_data():
     scheduler = TestScheduler()
@@ -693,12 +688,11 @@ def test_amb_regular_should_dispose_loser():
     scheduler = TestScheduler()
     msgs1 = [on_next(150, 1), on_next(210, 2), on_completed(240)]
     msgs2 = [on_next(150, 1), on_next(220, 3), on_completed(250)]
-    source_not_disposed = False
+    source_not_disposed = [False]
     o1 = scheduler.create_hot_observable(msgs1)
 
     def action():
-        nonlocal source_not_disposed
-        source_not_disposed = True
+        source_not_disposed[0] = True
 
     o2 = scheduler.create_hot_observable(msgs2).do_action(on_next=action)
     
@@ -707,19 +701,18 @@ def test_amb_regular_should_dispose_loser():
     results = scheduler.start(create)
     
     results.messages.assert_equal(on_next(210, 2), on_completed(240))
-    assert(not source_not_disposed)
+    assert(not source_not_disposed[0])
 
 def test_amb_winner_throws():
     ex = 'ex'
     scheduler = TestScheduler()
     msgs1 = [on_next(150, 1), on_next(210, 2), on_error(220, ex)]
     msgs2 = [on_next(150, 1), on_next(220, 3), on_completed(250)]
-    source_not_disposed = False
+    source_not_disposed = [False]
     o1 = scheduler.create_hot_observable(msgs1)
     
     def action():
-        nonlocal source_not_disposed
-        source_not_disposed = True
+        source_not_disposed[0] = True
     
     o2 = scheduler.create_hot_observable(msgs2).do_action(on_next=action)
     
@@ -728,18 +721,17 @@ def test_amb_winner_throws():
     
     results = scheduler.start(create)
     results.messages.assert_equal(on_next(210, 2), on_error(220, ex))
-    assert(not source_not_disposed)
+    assert(not source_not_disposed[0])
 
 def test_amb_loser_throws():
     ex = 'ex'
     scheduler = TestScheduler()
     msgs1 = [on_next(150, 1), on_next(220, 2), on_error(230, ex)]
     msgs2 = [on_next(150, 1), on_next(210, 3), on_completed(250)]
-    source_not_disposed = False
+    source_not_disposed = [False]
     
     def action():
-        nonlocal source_not_disposed
-        source_not_disposed = True
+        source_not_disposed[0] = True
     o1 = scheduler.create_hot_observable(msgs1).do_action(on_next=action)
     
     o2 = scheduler.create_hot_observable(msgs2)
@@ -749,19 +741,18 @@ def test_amb_loser_throws():
         
     results = scheduler.start(create)
     results.messages.assert_equal(on_next(210, 3), on_completed(250))
-    assert(not source_not_disposed)
+    assert(not source_not_disposed[0])
 
 def test_amb_throws_before_election():
     ex = 'ex'
     scheduler = TestScheduler()
     msgs1 = [on_next(150, 1), on_error(210, ex)]
     msgs2 = [on_next(150, 1), on_next(220, 3), on_completed(250)]
-    source_not_disposed = False
+    source_not_disposed = [False]
     o1 = scheduler.create_hot_observable(msgs1)
     
     def action():
-        nonlocal source_not_disposed
-        source_not_disposed = True
+        source_not_disposed[0] = True
     
     o2 = scheduler.create_hot_observable(msgs2).do_action(on_next=action)
     
@@ -771,7 +762,7 @@ def test_amb_throws_before_election():
     results = scheduler.start(create)
     
     results.messages.assert_equal(on_error(210, ex))
-    assert(not source_not_disposed)
+    assert(not source_not_disposed[0])
 
 def test_catch_no_errors():
     scheduler = TestScheduler()
@@ -882,7 +873,7 @@ def test_catch_multiple():
 
 def test_catch_error_specific_caught():
     ex = 'ex'
-    handler_called = False
+    handler_called = [False]
     scheduler = TestScheduler()
     msgs1 = [on_next(150, 1), on_next(210, 2), on_next(220, 3), on_error(230, ex)]
     msgs2 = [on_next(240, 4), on_completed(250)]
@@ -891,9 +882,7 @@ def test_catch_error_specific_caught():
     
     def create():
         def handler(e):
-            nonlocal handler_called
-            
-            handler_called = True
+            handler_called[0] = True
             return o2
 
         return o1.catch_exception(handler)
@@ -901,19 +890,18 @@ def test_catch_error_specific_caught():
     results = scheduler.start(create)
 
     results.messages.assert_equal(on_next(210, 2), on_next(220, 3), on_next(240, 4), on_completed(250))
-    assert(handler_called)
+    assert(handler_called[0])
 
 def test_catch_error_specific_caught_immediate():
     ex = 'ex'
-    handler_called = False
+    handler_called = [False]
     scheduler = TestScheduler()
     msgs2 = [on_next(240, 4), on_completed(250)]
     o2 = scheduler.create_hot_observable(msgs2)
 
     def create():
         def handler(e):
-            nonlocal handler_called
-            handler_called = True
+            handler_called[0] = True
             return o2
 
         return Observable.throw_exception('ex').catch_exception(handler)
@@ -921,32 +909,31 @@ def test_catch_error_specific_caught_immediate():
     results = scheduler.start(create)
         
     results.messages.assert_equal(on_next(240, 4), on_completed(250))
-    assert(handler_called)
+    assert(handler_called[0])
 
 def test_catch_handler_throws():
     ex = 'ex'
     ex2 = 'ex2'
-    handler_called = False
+    handler_called = [False]
     scheduler = TestScheduler()
     msgs1 = [on_next(150, 1), on_next(210, 2), on_next(220, 3), on_error(230, ex)]
     o1 = scheduler.create_hot_observable(msgs1)
     
     def create():
         def handler(e):
-            nonlocal handler_called
-            handler_called = True
+            handler_called[0] = True
             raise Exception(ex2)
         return o1.catch_exception(handler)
     
     results = scheduler.start(create)
         
     results.messages.assert_equal(on_next(210, 2), on_next(220, 3), on_error(230, ex2))
-    assert(handler_called)
+    assert(handler_called[0])
 
 def test_catch_nested_outer_catches():
     ex = 'ex'
-    first_handler_called = False
-    second_handler_called = False
+    first_handler_called = [False]
+    second_handler_called = [False]
     scheduler = TestScheduler()
     msgs1 = [on_next(150, 1), on_next(210, 2), on_error(215, ex)]
     msgs2 = [on_next(220, 3), on_completed(225)]
@@ -957,26 +944,24 @@ def test_catch_nested_outer_catches():
     
     def create():
         def handler1(e):
-            nonlocal first_handler_called
-            first_handler_called = True
+            first_handler_called[0] = True
             return o2
         def handler2(e):
-            nonlocal second_handler_called
-            second_handler_called = True
+            second_handler_called[0] = True
             return o3
         return o1.catch_exception(handler1).catch_exception(handler2)
     
     results = scheduler.start(create)    
     
     results.messages.assert_equal(on_next(210, 2), on_next(220, 3), on_completed(225))
-    assert(first_handler_called)
-    assert(not second_handler_called)
+    assert(first_handler_called[0])
+    assert(not second_handler_called[0])
 
 def test_catch_throw_from_nested_catch():
     ex = 'ex'
     ex2 = 'ex'
-    first_handler_called = False
-    second_handler_called = False
+    first_handler_called = [False]
+    second_handler_called = [False]
     scheduler = TestScheduler()
     msgs1 = [on_next(150, 1), on_next(210, 2), on_error(215, ex)]
     msgs2 = [on_next(220, 3), on_error(225, ex2)]
@@ -987,13 +972,11 @@ def test_catch_throw_from_nested_catch():
     
     def create():
         def handler1(e):
-            nonlocal first_handler_called
-            first_handler_called = True
+            first_handler_called[0] = True
             assert(e == ex)
             return o2
         def handler2(e):
-            nonlocal second_handler_called
-            second_handler_called = True
+            second_handler_called[0] = True
             assert(e == ex2)
             return o3
         return o1.catch_exception(handler1).catch_exception(handler2)
@@ -1001,8 +984,8 @@ def test_catch_throw_from_nested_catch():
     results = scheduler.start(create)
     
     results.messages.assert_equal(on_next(210, 2), on_next(220, 3), on_next(230, 4), on_completed(235))
-    assert(first_handler_called)
-    assert(second_handler_called)
+    assert(first_handler_called[0])
+    assert(second_handler_called[0])
 
 def test_on_error_resume_next_no_errors():
     scheduler = TestScheduler()

--- a/tests/test_observable_time.py
+++ b/tests/test_observable_time.py
@@ -226,7 +226,7 @@ def test_delay_datetime_offset_simple1_impl():
     xs = scheduler.create_hot_observable(on_next(150, 1), on_next(250, 2), on_next(350, 3), on_next(450, 4), on_completed(550))
     
     def create():
-        dt = datetime.fromtimestamp(300/1000)
+        dt = datetime.fromtimestamp(300/1000.0)
         return xs.delay(dt, scheduler)
     
     results = scheduler.start(create)
@@ -249,7 +249,7 @@ def test_delay_datetime_offset_simple2_impl():
     xs = scheduler.create_hot_observable(on_next(150, 1), on_next(250, 2), on_next(350, 3), on_next(450, 4), on_completed(550))
     
     def create():
-        return xs.delay(datetime.fromtimestamp(250/1000), scheduler)
+        return xs.delay(datetime.fromtimestamp(250/1000.0), scheduler)
     
     results = scheduler.start(create)
         
@@ -628,7 +628,7 @@ def test_throttle_duration_inner_done_throttle_behavior():
 class TimeInterval(object):
     def __init__(self, value, interval):
         if isinstance(interval, timedelta):
-            interval = int(interval.microseconds/1000)
+            interval = int(interval.microseconds/1000.0)
 
         self.value = value
         self.interval = interval
@@ -918,7 +918,7 @@ def test_timeout_datetime_offset_timeout_occurs():
     ys = scheduler.create_cold_observable(on_next(100, -1))
     
     def create():
-        return xs.timeout(datetime.fromtimestamp(400/1000), ys, scheduler=scheduler)
+        return xs.timeout(datetime.fromtimestamp(400/1000.0), ys, scheduler=scheduler)
     
     results = scheduler.start(create)
     
@@ -932,7 +932,7 @@ def test_timeout_datetime_offset_timeout_does_not_occur_completed():
     ys = scheduler.create_cold_observable(on_next(100, -1))
 
     def create():
-        return xs.timeout(datetime.fromtimestamp(400/1000), ys, scheduler=scheduler)
+        return xs.timeout(datetime.fromtimestamp(400/1000.0), ys, scheduler=scheduler)
     results = scheduler.start(create)
     
     results.messages.assert_equal(on_next(310, 1), on_completed(390))
@@ -946,7 +946,7 @@ def test_timeout_datetime_offset_timeout_does_not_occur_error():
     ys = scheduler.create_cold_observable(on_next(100, -1))
     
     def create():
-        return xs.timeout(datetime.fromtimestamp(400/1000), ys, scheduler=scheduler)
+        return xs.timeout(datetime.fromtimestamp(400/1000.0), ys, scheduler=scheduler)
     
     results = scheduler.start(create)
         
@@ -960,7 +960,7 @@ def test_timeout_datetime_offset_timeout_occur_2():
     ys = scheduler.create_cold_observable(on_next(100, -1))
     
     def create():
-        return xs.timeout(datetime.fromtimestamp(400/1000), ys, scheduler=scheduler)
+        return xs.timeout(datetime.fromtimestamp(400/1000.0), ys, scheduler=scheduler)
     
     results = scheduler.start(create)
         
@@ -974,7 +974,7 @@ def test_timeout_datetime_offset_timeout_occur_3():
     ys = scheduler.create_cold_observable()
     
     def create():
-        return xs.timeout(datetime.fromtimestamp(400/1000), ys, scheduler)
+        return xs.timeout(datetime.fromtimestamp(400/1000.0), ys, scheduler)
     
     results = scheduler.start(create)
         

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -60,32 +60,30 @@ def test_to_notifier_forwards():
     assert(obsc.has_on_completed)
 
 def test_create_on_next():
-    next = False
+    next = [False]
     def on_next(x):
-        nonlocal next
         assert(42 == x)
-        next = True
+        next[0] = True
 
     res = Observer(on_next)
     
     res.on_next(42)
-    assert(next)
+    assert(next[0])
     return res.on_completed()
 
 def test_create_on_next_has_error():
     ex = 'ex'
-    next = False
+    next = [False]
     _e = None
 
     def on_next(x):
-        nonlocal next
         assert(42 == x)
-        next = True
+        next[0] = True
 
     res = Observer(on_next)
     
     res.on_next(42)
-    assert(next)
+    assert(next[0])
     
     try:
         res.on_error(ex)
@@ -96,53 +94,49 @@ def test_create_on_next_has_error():
     assert(ex == e_)
 
 def test_create_on_next_on_completed():
-    next = False
-    completed = False
+    next = [False]
+    completed = [False]
 
     def on_next(x):
-        nonlocal next
         assert(42 == x)
-        next = True
-        return next
+        next[0] = True
+        return next[0]
 
     def on_completed():
-        nonlocal completed
-        completed = True
-        return completed
+        completed[0] = True
+        return completed[0]
 
     res = Observer(on_next, None, on_completed)
     
     res.on_next(42)
 
-    assert(next)
-    assert(not completed)
+    assert(next[0])
+    assert(not completed[0])
 
     res.on_completed()
 
-    assert(completed)
+    assert(completed[0])
 
 
 def test_create_on_next_on_completed_has_error():
     e_ = None
     ex = 'ex'
-    next = False
-    completed = False
+    next = [False]
+    completed = [False]
 
 
     def on_next(x):
-        nonlocal next
         assert(42 == x)
-        next = True
+        next[0] = True
 
     def on_completed():
-        nonlocal completed
-        completed = True
+        completed[0] = True
 
     res = Observer(on_next, None, on_completed)
     
     res.on_next(42)
-    assert(next)
-    assert(not completed)
+    assert(next[0])
+    assert(not completed[0])
     try:
         res.on_error(ex)
         assert(False)
@@ -150,125 +144,115 @@ def test_create_on_next_on_completed_has_error():
         e_ = e.args[0]
     
     assert(ex == e_)
-    assert(not completed)
+    assert(not completed[0])
 
 
 def test_create_on_next_on_error():
     ex = 'ex'
-    next = True
-    error = False
+    next = [True]
+    error = [False]
 
     def on_next(x):
-        nonlocal next
         assert(42 == x)
-        next = True
+        next[0] = True
     
     def on_error(e):
-        nonlocal error
         assert(ex == e)
-        error = True
+        error[0] = True
 
     res = Observer(on_next, on_error)
     
     res.on_next(42)
 
-    assert(next)
-    assert(not error)
+    assert(next[0])
+    assert(not error[0])
 
     res.on_error(ex)
-    assert(error)
+    assert(error[0])
 
 
 def test_create_on_next_on_error_hit_completed():
     ex = 'ex'
-    next = True
-    error = False
+    next = [True]
+    error = [False]
     
     def on_next(x):
-        nonlocal next
         assert(42 == x)
-        next = True
+        next[0] = True
     
     def on_error(e):
-        nonlocal error
         assert(ex == e)
-        error = True
+        error[0] = True
 
     res = Observer(on_next, on_error)
 
     res.on_next(42)
-    assert(next)
-    assert(not error)
+    assert(next[0])
+    assert(not error[0])
 
     res.on_completed()
 
-    assert(not error)
+    assert(not error[0])
 
 def test_create_on_next_on_error_on_completed1():
     ex = 'ex'
-    next = True
-    error = False
-    completed = False
+    next = [True]
+    error = [False]
+    completed = [False]
     
     def on_next(x):
-        nonlocal next
         assert(42 == x)
-        next = True
+        next[0] = True
     
     def on_error(e):
-        nonlocal error
         assert(ex == e)
-        error = True
+        error[0] = True
 
     def on_completed():
-        nonlocal completed
-        completed = True
+        completed[0] = True
 
     res = Observer(on_next, on_error, on_completed)
 
     res.on_next(42)
 
-    assert(next)
-    assert(not error)
-    assert(not completed)
+    assert(next[0])
+    assert(not error[0])
+    assert(not completed[0])
 
     res.on_completed()
 
-    assert(completed)
-    assert(not error)
+    assert(completed[0])
+    assert(not error[0])
 
 def test_create_on_next_on_error_on_completed2():
     ex = 'ex'
-    next = True
-    error = False
-    completed = False
+    next = [True]
+    error = [False]
+    completed = [False]
 
     def on_next(x):
-        nonlocal next
         assert(42 == x)
-        next = True
+        next[0] = True
     
     def on_error(e):
-        nonlocal error
         assert(ex == e)
-        error = True
+        error[0] = True
 
     def on_completed():
-        nonlocal completed
-        completed = True
+        completed[0] = True
 
     res = Observer(on_next, on_error, on_completed)
 
     res.on_next(42)
 
-    assert(next)
-    assert(not error)
-    assert(not completed)
+    assert(next[0])
+    assert(not error[0])
+    assert(not completed[0])
 
     res.on_error(ex)
     
-    assert(not completed)
-    assert(error)
+    assert(not completed[0])
+    assert(error[0])
 
 def test_as_observer_hides():
     obs = MyObserver()
@@ -294,18 +278,16 @@ def test_as_observer_forwards():
 
 
 def test_observer_checked_already_terminated_completed():
-    m, n = 0, 0
+    m, n = [0], [0]
 
     def on_next(x):
-        nonlocal m
-        m += 1
+        m[0] += 1
 
     def on_error(x):
         assert(False)
 
     def on_completed():
-        nonlocal n
-        n += 1
+        n[0] += 1
 
     o = Observer(on_next, on_error, on_completed).checked()
 
@@ -320,20 +302,18 @@ def test_observer_checked_already_terminated_completed():
     except Exception:
         pass
 
-    assert(2 == m)
-    assert(1 == n)
+    assert(2 == m[0])
+    assert(1 == n[0])
 
 
 def test_observer_checked_already_terminated_error():
-    m, n = 0, 0
+    m, n = [0], [0]
 
     def on_next(x):
-        nonlocal m
-        m += 1
+        m[0] += 1
 
     def on_error(x):
-        nonlocal n
-        n += 1
+        n[0] += 1
 
     def on_completed():
         assert(False)
@@ -354,15 +334,14 @@ def test_observer_checked_already_terminated_error():
     except Exception:
         pass 
 
-    assert(2 == m)
-    assert(1 == n)
+    assert(2 == m[0])
+    assert(1 == n[0])
 
 def test_observer_checked_reentrant_next():
     ex = "Re-entrancy detected"
-    n = 0
+    n = [0]
     def on_next(x):
-        nonlocal n
-        n += 1
+        n[0] += 1
 
         try:
             o.on_next(9)
@@ -387,18 +366,17 @@ def test_observer_checked_reentrant_next():
     o = Observer(on_next, on_error, on_completed).checked()
 
     o.on_next(1)
-    assert(1 == n)
+    assert(1 == n[0])
 
 def test_observer_checked_reentrant_error():
     msg = "Re-entrancy detected"
-    n = 0
+    n = [0]
     
     def on_next(x):
         assert(False)
         
     def on_error(ex):
-        nonlocal n
-        n += 1
+        n[0] += 1
 
         try:
             o.on_next(9)
@@ -420,12 +398,12 @@ def test_observer_checked_reentrant_error():
 
     o = Observer(on_next, on_error, on_completed).checked()
     o.on_error(Exception('error'))
-    assert(1 == n)
+    assert(1 == n[0])
 
 
 def test_observer_checked_reentrant_completed():
     msg = "Re-entrancy detected"
-    n = 0
+    n = [0]
 
     def on_next(x):
         assert(False)
@@ -434,8 +412,7 @@ def test_observer_checked_reentrant_completed():
         assert(False)
 
     def on_completed():
-        nonlocal n
-        n += 1
+        n[0] += 1
         try:
             o.on_next(9)
         except Exception as e:
@@ -456,7 +433,7 @@ def test_observer_checked_reentrant_completed():
     o = Observer(on_next, on_error, on_completed).checked()
 
     o.on_completed()
-    assert(1 == n)
+    assert(1 == n[0])
 
 if __name__ == '__main__':
     test_to_notifier_forwards()

--- a/tests/test_replaysubject.py
+++ b/tests/test_replaysubject.py
@@ -40,59 +40,54 @@ def test_infinite():
         on_next(1020, 12)
     )
 
-    subject = None
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    subject = [None]
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = ReplaySubject(3, 100, scheduler)
+        subject[0] = ReplaySubject(3, 100, scheduler)
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(subject)
+        subscription[0] = xs.subscribe(subject[0])
     scheduler.schedule_absolute(200, action2) 
     
     def action3(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action3)
 
     def action4(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(300, action4)
 
     def action5(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(400, action5)
 
     def action6(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(900, action6)
 
     def action7(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action7)
     
     def action8(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action8)
     
     def action9(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action9)
     
     def action10(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action10)
 
     scheduler.start()
@@ -138,59 +133,54 @@ def test_infinite2():
         on_next(1020, 12)
     )
 
-    subject = None
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    subject = [None]
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = ReplaySubject(3, 100, scheduler)
+        subject[0] = ReplaySubject(3, 100, scheduler)
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(subject)
+        subscription[0] = xs.subscribe(subject[0])
     scheduler.schedule_absolute(200, action2)
     
     def action3(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action3)
 
     def action4(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(300, action4)
     
     def action5(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(400, action5)
     
     def action6(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(900, action6)
     
     def action7(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action7)
     
     def action8(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action8)
     
     def action9(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action9)
     
     def action10(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action10)
     
     scheduler.start()
@@ -233,59 +223,54 @@ def test_finite():
         on_error(660, 'ex')
     )
 
-    subject = None
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    subject = [None]
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = ReplaySubject(3, 100, scheduler)
+        subject[0] = ReplaySubject(3, 100, scheduler)
     scheduler.schedule_absolute(100, action1)
     
     def action3(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(subject)
+        subscription[0] = xs.subscribe(subject[0])
     scheduler.schedule_absolute(200, action3)
 
     def action4(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action4)
 
     def action5(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(300, action5)
     
     def action6(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(400, action6)
 
     def action7(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(900, action7)
 
     def action8(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action8)
 
     def action9(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action9)
     
     def action10(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action10)
     
     def action11(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action11)
 
     scheduler.start()
@@ -328,59 +313,54 @@ def test_error():
         on_error(660, RxException('ex'))
     )
 
-    subject = None
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    subject = [None]
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = ReplaySubject(3, 100, scheduler)
+        subject[0] = ReplaySubject(3, 100, scheduler)
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(subject)
+        subscription[0] = xs.subscribe(subject[0])
     scheduler.schedule_absolute(200, action2)
 
     def action3(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action3)
 
     def action4(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(300, action4)
     
     def action5(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(400, action5)
     
     def action6(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(900, action6)
     
     def action7(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action7)
     
     def action8(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action8)
     
     def action9(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action9)
     
     def action10(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action10)
     
     scheduler.start()
@@ -414,59 +394,54 @@ def test_canceled():
         on_error(660, RxException())
     )
 
-    subject = None
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    subject = [None]
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = ReplaySubject(3, 100, scheduler)
+        subject[0] = ReplaySubject(3, 100, scheduler)
     scheduler.schedule_absolute(100, action1)
 
     def action2(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(subject)
+        subscription[0] = xs.subscribe(subject[0])
     scheduler.schedule_absolute(200, action2)
     
     def action3(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action3)
     
     def action4(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(300, action4)
     
     def action5(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(400, action5)
     
     def action6(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(900, action6)
     
     def action7(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action7)
     
     def action8(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action8)
     
     def action9(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action9)
     
     def action10(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action10)
     
     scheduler.start()
@@ -485,90 +460,86 @@ def test_canceled():
 def test_subject_disposed():
     scheduler = TestScheduler()
 
-    subject = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    subject = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
     results3 = scheduler.create_observer()
 
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = ReplaySubject(scheduler=scheduler)
+        subject[0] = ReplaySubject(scheduler=scheduler)
     scheduler.schedule_absolute(100, action1)
     
     def action2(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = subject.subscribe(results1)
+        subscription1[0] = subject[0].subscribe(results1)
     scheduler.schedule_absolute(200, action2)
     
     def action3(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = subject.subscribe(results2)
+        subscription2[0] = subject[0].subscribe(results2)
     scheduler.schedule_absolute(300, action3)
     
     def action4(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = subject.subscribe(results3)
+        subscription3[0] = subject[0].subscribe(results3)
     scheduler.schedule_absolute(400, action4)
     
     def action5(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(500, action5)
     
     def action6(scheduler, state=None):
-        subject.dispose()
+        subject[0].dispose()
     scheduler.schedule_absolute(600, action6)
     
     def action7(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action7)
     
     def action8(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(800, action8)
     
     def action9(scheduler, state=None):
-        subject.on_next(1)
+        subject[0].on_next(1)
     scheduler.schedule_absolute(150, action9)
     
     def action10(scheduler, state=None):
-        subject.on_next(2)
+        subject[0].on_next(2)
     scheduler.schedule_absolute(250, action10)
     
     def action11(scheduler, state=None):
-        subject.on_next(3)
+        subject[0].on_next(3)
     scheduler.schedule_absolute(350, action11)
     
     def action12(scheduler, state=None):
-        subject.on_next(4)
+        subject[0].on_next(4)
     scheduler.schedule_absolute(450, action12)
     
     def action13(scheduler, state=None):
-        subject.on_next(5)
+        subject[0].on_next(5)
     scheduler.schedule_absolute(550, action13)
     
     @raises(DisposedException)
     def action14(scheduler, state=None):
-        subject.on_next(6)
+        subject[0].on_next(6)
     scheduler.schedule_absolute(650, action14)
 
     @raises(DisposedException)
     def action15(scheduler, state=None):
-        subject.on_completed()
+        subject[0].on_completed()
     scheduler.schedule_absolute(750, action15)
     
     @raises(DisposedException)
     def action16(scheduler, state=None):
-        subject.on_error(Exception())
+        subject[0].on_error(Exception())
         
     scheduler.schedule_absolute(850, action16)
     
     @raises(DisposedException)
     def action17(scheduler, state=None):
-        subject.subscribe(None)
+        subject[0].subscribe(None)
         
     scheduler.schedule_absolute(950, action17)
 
@@ -611,7 +582,7 @@ def test_replay_subject_dies_out():
         on_completed(580)
     )
 
-    subject = None
+    subject = [None]
 
     results1 = scheduler.create_observer()
     results2 = scheduler.create_observer()
@@ -619,28 +590,27 @@ def test_replay_subject_dies_out():
     results4 = scheduler.create_observer()
 
     def action1(scheduler, state=None):
-        nonlocal subject
-        subject = ReplaySubject(sys.maxsize, 100, scheduler)
+        subject[0] = ReplaySubject(sys.maxsize, 100, scheduler)
     scheduler.schedule_absolute(100, action1)
     
     def action2(scheduler, state=None):
-        xs.subscribe(subject)
+        xs.subscribe(subject[0])
     scheduler.schedule_absolute(200, action2)
     
     def action3(scheduler, state=None):
-        subject.subscribe(results1)
+        subject[0].subscribe(results1)
     scheduler.schedule_absolute(300, action3)
     
     def action4(scheduler, state=None):
-        subject.subscribe(results2)
+        subject[0].subscribe(results2)
     scheduler.schedule_absolute(400, action4)
     
     def action5(scheduler, state=None):
-        subject.subscribe(results3)
+        subject[0].subscribe(results3)
     scheduler.schedule_absolute(600, action5)
     
     def action6(scheduler, state=None):
-        subject.subscribe(results4)
+        subject[0].subscribe(results4)
     scheduler.schedule_absolute(900, action6)
     
     scheduler.start()

--- a/tests/test_standardqueryoperators/test_group_by.py
+++ b/tests/test_standardqueryoperators/test_group_by.py
@@ -1,5 +1,6 @@
 import math
 from datetime import datetime
+import six
 
 from rx.observable import Observable
 from rx.testing import TestScheduler, ReactiveTest
@@ -213,7 +214,7 @@ def test_group_by_inner_complete():
     
     def action3(scheduler, state):
         c["outer_subscription"].dispose()
-        for sub in c["inner_subscriptions"].values():
+        for sub in six.itervalues(c["inner_subscriptions"]):
             sub.dispose()
         
     scheduler.schedule_absolute(disposed, action3)
@@ -259,7 +260,7 @@ def test_group_by_inner_complete_all():
 
     def action3(scheduler, state):
         c["outer_subscription"].dispose()
-        for sub in inner_subscriptions.values():
+        for sub in six.itervalues(inner_subscriptions):
             sub.dispose()
     scheduler.schedule_absolute(disposed, action3)
         
@@ -310,7 +311,7 @@ def test_group_by_inner_error():
 
     def action4(scheduler, state):
         c["outer_subscription"].dispose();
-        for sub in inner_subscriptions.values():
+        for sub in six.itervalues(inner_subscriptions):
             sub.dispose()
     scheduler.schedule_absolute(disposed, action4)
 

--- a/tests/test_standardqueryoperators/test_group_by.py
+++ b/tests/test_standardqueryoperators/test_group_by.py
@@ -22,7 +22,7 @@ def _raise(ex):
 
 def test_group_by_with_key_comparer():
     scheduler = TestScheduler()
-    key_invoked = 0
+    key_invoked = [0]
     xs = scheduler.create_hot_observable(
                         on_next(90, "error"),
                         on_next(110, "error"),
@@ -46,8 +46,7 @@ def test_group_by_with_key_comparer():
 
     def factory():
         def key_selector(x):
-            nonlocal key_invoked
-            key_invoked += 1
+            key_invoked[0] += 1
             return x.lower().strip()
         
         return xs.group_by(key_selector, lambda x: x).select(lambda g: g.key)
@@ -55,23 +54,21 @@ def test_group_by_with_key_comparer():
     results = scheduler.start(factory)
     results.messages.assert_equal(on_next(220, "foo"), on_next(270, "bar"), on_next(350, "baz"), on_next(360, "qux"), on_completed(570))
     xs.subscriptions.assert_equal(subscribe(200, 570))
-    assert(key_invoked == 12)
+    assert(key_invoked[0] == 12)
 
 def test_groupby_outer_complete():
     scheduler = TestScheduler()
-    key_invoked = 0
-    ele_invoked = 0
+    key_invoked = [0]
+    ele_invoked = [0]
     xs = scheduler.create_hot_observable(on_next(90, "error"), on_next(110, "error"), on_next(130, "error"), on_next(220, "  foo"), on_next(240, " FoO "), on_next(270, "baR  "), on_next(310, "foO "), on_next(350, " Baz   "), on_next(360, "  qux "), on_next(390, "   bar"), on_next(420, " BAR  "), on_next(470, "FOO "), on_next(480, "baz  "), on_next(510, " bAZ "), on_next(530, "    fOo    "), on_completed(570), on_next(580, "error"), on_completed(600), on_error(650, 'ex'))
     
     def factory():
         def key_selector(x):
-            nonlocal key_invoked
-            key_invoked += 1
+            key_invoked[0] += 1
             return x.lower().strip()
 
         def element_selector(x):
-            nonlocal ele_invoked
-            ele_invoked += 1
+            ele_invoked[0] += 1
             return x[::-1] # Yes, this is reverse string in Python
 
         return xs.group_by(key_selector, element_selector).select(lambda g: g.key)
@@ -79,24 +76,22 @@ def test_groupby_outer_complete():
     results = scheduler.start(factory)
     results.messages.assert_equal(on_next(220, "foo"), on_next(270, "bar"), on_next(350, "baz"), on_next(360, "qux"), on_completed(570))
     xs.subscriptions.assert_equal(subscribe(200, 570))
-    assert(key_invoked == 12)
-    assert(ele_invoked == 12)
+    assert(key_invoked[0] == 12)
+    assert(ele_invoked[0] == 12)
 
 def test_group_by_outer_error():
     scheduler = TestScheduler()
-    key_invoked = 0
-    ele_invoked = 0
+    key_invoked = [0]
+    ele_invoked = [0]
     ex = 'ex'
     xs = scheduler.create_hot_observable(on_next(90, "error"), on_next(110, "error"), on_next(130, "error"), on_next(220, "  foo"), on_next(240, " FoO "), on_next(270, "baR  "), on_next(310, "foO "), on_next(350, " Baz   "), on_next(360, "  qux "), on_next(390, "   bar"), on_next(420, " BAR  "), on_next(470, "FOO "), on_next(480, "baz  "), on_next(510, " bAZ "), on_next(530, "    fOo    "), on_error(570, ex), on_next(580, "error"), on_completed(600), on_error(650, 'ex'))
     
     def factory():
         def key_selector(x):
-            nonlocal key_invoked
-            key_invoked += 1
+            key_invoked[0] += 1
             return x.lower().strip()
         def element_selector(x):
-            nonlocal ele_invoked
-            ele_invoked += 1
+            ele_invoked[0] += 1
             return x[::-1]
         
         return xs.group_by(key_selector, element_selector).select(lambda g: g.key)
@@ -105,25 +100,23 @@ def test_group_by_outer_error():
 
     results.messages.assert_equal(on_next(220, "foo"), on_next(270, "bar"), on_next(350, "baz"), on_next(360, "qux"), on_error(570, ex))
     xs.subscriptions.assert_equal(subscribe(200, 570))
-    assert(key_invoked == 12)
-    assert(ele_invoked == 12)
+    assert(key_invoked[0] == 12)
+    assert(ele_invoked[0] == 12)
 
 
 def test_group_by_outer_dispose():
     scheduler = TestScheduler()
-    key_invoked = 0
-    ele_invoked = 0
+    key_invoked = [0]
+    ele_invoked = [0]
     xs = scheduler.create_hot_observable(on_next(90, "error"), on_next(110, "error"), on_next(130, "error"), on_next(220, "  foo"), on_next(240, " FoO "), on_next(270, "baR  "), on_next(310, "foO "), on_next(350, " Baz   "), on_next(360, "  qux "), on_next(390, "   bar"), on_next(420, " BAR  "), on_next(470, "FOO "), on_next(480, "baz  "), on_next(510, " bAZ "), on_next(530, "    fOo    "), on_completed(570), on_next(580, "error"), on_completed(600), on_error(650, 'ex'))
     
     def factory():
         def key_selector(x):
-            nonlocal key_invoked
-            key_invoked += 1
+            key_invoked[0] += 1
             return x.lower().strip()
         
         def element_selector(x):
-            nonlocal ele_invoked
-            ele_invoked += 1
+            ele_invoked[0] += 1
             return x[::-1]
 
         return xs.group_by(key_selector, element_selector).select(lambda g: g.key)
@@ -132,27 +125,25 @@ def test_group_by_outer_dispose():
     
     results.messages.assert_equal(on_next(220, "foo"), on_next(270, "bar"), on_next(350, "baz"))
     xs.subscriptions.assert_equal(subscribe(200, 355))
-    assert(key_invoked == 5)
-    assert(ele_invoked == 5)
+    assert(key_invoked[0] == 5)
+    assert(ele_invoked[0] == 5)
 
 def test_group_by_outer_key_throw():
     scheduler = TestScheduler()
-    key_invoked = 0
-    ele_invoked = 0
+    key_invoked = [0]
+    ele_invoked = [0]
     ex = 'ex'
     xs = scheduler.create_hot_observable(on_next(90, "error"), on_next(110, "error"), on_next(130, "error"), on_next(220, "  foo"), on_next(240, " FoO "), on_next(270, "baR  "), on_next(310, "foO "), on_next(350, " Baz   "), on_next(360, "  qux "), on_next(390, "   bar"), on_next(420, " BAR  "), on_next(470, "FOO "), on_next(480, "baz  "), on_next(510, " bAZ "), on_next(530, "    fOo    "), on_completed(570), on_next(580, "error"), on_completed(600), on_error(650, 'ex'))
     def factory():
         def key_selector(x):
-            nonlocal key_invoked
-            key_invoked += 1
-            if key_invoked == 10:
+            key_invoked[0] += 1
+            if key_invoked[0] == 10:
                 raise Exception(ex)
             
             return x.lower().strip()
 
         def element_selector(x):
-            nonlocal ele_invoked
-            ele_invoked += 1
+            ele_invoked[0] += 1
             return x[::-1]
         
         return xs.group_by(key_selector, element_selector).select(lambda g: g.key)
@@ -160,26 +151,24 @@ def test_group_by_outer_key_throw():
     results = scheduler.start(factory)
     results.messages.assert_equal(on_next(220, "foo"), on_next(270, "bar"), on_next(350, "baz"), on_next(360, "qux"), on_error(480, ex))
     xs.subscriptions.assert_equal(subscribe(200, 480))
-    assert(key_invoked == 10)
-    assert(ele_invoked == 9)
+    assert(key_invoked[0] == 10)
+    assert(ele_invoked[0] == 9)
 
 def test_group_by_outer_ele_throw():
     scheduler = TestScheduler()
-    key_invoked = 0
-    ele_invoked = 0
+    key_invoked = [0]
+    ele_invoked = [0]
     ex = 'ex'
     xs = scheduler.create_hot_observable(on_next(90, "error"), on_next(110, "error"), on_next(130, "error"), on_next(220, "  foo"), on_next(240, " FoO "), on_next(270, "baR  "), on_next(310, "foO "), on_next(350, " Baz   "), on_next(360, "  qux "), on_next(390, "   bar"), on_next(420, " BAR  "), on_next(470, "FOO "), on_next(480, "baz  "), on_next(510, " bAZ "), on_next(530, "    fOo    "), on_completed(570), on_next(580, "error"), on_completed(600), on_error(650, 'ex'))
     
     def factory():
         def key_selector(x):
-            nonlocal key_invoked
-            key_invoked += 1
+            key_invoked[0] += 1
             return x.lower().strip()
         
         def element_selector(x):
-            nonlocal ele_invoked
-            ele_invoked += 1
-            if ele_invoked == 10:
+            ele_invoked[0] += 1
+            if ele_invoked[0] == 10:
                 raise Exception(ex)
             return x[::-1]
 
@@ -188,91 +177,88 @@ def test_group_by_outer_ele_throw():
     results = scheduler.start(factory)
     results.messages.assert_equal(on_next(220, "foo"), on_next(270, "bar"), on_next(350, "baz"), on_next(360, "qux"), on_error(480, ex))
     xs.subscriptions.assert_equal(subscribe(200, 480))
-    assert(key_invoked == 10)
-    assert(ele_invoked == 10)
+    assert(key_invoked[0] == 10)
+    assert(ele_invoked[0] == 10)
 
 def test_group_by_inner_complete():
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, "error"), on_next(110, "error"), on_next(130, "error"), on_next(220, "  foo"), on_next(240, " FoO "), on_next(270, "baR  "), on_next(310, "foO "), on_next(350, " Baz   "), on_next(360, "  qux "), on_next(390, "   bar"), on_next(420, " BAR  "), on_next(470, "FOO "), on_next(480, "baz  "), on_next(510, " bAZ "), on_next(530, "    fOo    "), on_completed(570), on_next(580, "error"), on_completed(600), on_error(650, 'ex'))
-    outer_subscription = None
-    inner_subscriptions = {}
-    inners = {}
-    results = {}
-    outer = None
+    c = {
+        "outer_subscription": None,
+        "inner_subscriptions": {},
+        "inners": {},
+        "results": {},
+        "outer": None
+    }
 
     def action1(scheduler, state):
-        nonlocal outer
-        outer = xs.group_by(lambda x: x.lower().strip(), lambda x: x[::-1])
+        c["outer"] = xs.group_by(lambda x: x.lower().strip(), lambda x: x[::-1])
     
     scheduler.schedule_absolute(created, action1)
     
     def action2(scheduler, state):
-        nonlocal outer_subscription
 
         def next(group):
-            nonlocal results, inners
 
             result = scheduler.create_observer()
-            inners[group.key] = group
-            results[group.key] = result
+            c["inners"][group.key] = group
+            c["results"][group.key] = result
 
             def action21(scheduler, state):
-                nonlocal inner_subscriptions
-                inner_subscriptions[group.key] = group.subscribe(result)
+                c["inner_subscriptions"][group.key] = group.subscribe(result)
 
             scheduler.schedule_relative(100, action21)
-        outer_subscription = outer.subscribe(next)
+        c["outer_subscription"] = c["outer"].subscribe(next)
     scheduler.schedule_absolute(subscribed, action2)
     
     def action3(scheduler, state):
-        outer_subscription.dispose()
-        for sub in inner_subscriptions.values():
+        c["outer_subscription"].dispose()
+        for sub in c["inner_subscriptions"].values():
             sub.dispose()
         
     scheduler.schedule_absolute(disposed, action3)
     scheduler.start()
-    assert(len(inners) == 4)
-    results['foo'].messages.assert_equal(on_next(470, " OOF"), on_next(530, "    oOf    "), on_completed(570))
-    results['bar'].messages.assert_equal(on_next(390, "rab   "), on_next(420, "  RAB "), on_completed(570))
-    results['baz'].messages.assert_equal(on_next(480, "  zab"), on_next(510, " ZAb "), on_completed(570))
-    results['qux'].messages.assert_equal(on_completed(570))
+    assert(len(c["inners"]) == 4)
+    c["results"]['foo'].messages.assert_equal(on_next(470, " OOF"), on_next(530, "    oOf    "), on_completed(570))
+    c["results"]['bar'].messages.assert_equal(on_next(390, "rab   "), on_next(420, "  RAB "), on_completed(570))
+    c["results"]['baz'].messages.assert_equal(on_next(480, "  zab"), on_next(510, " ZAb "), on_completed(570))
+    c["results"]['qux'].messages.assert_equal(on_completed(570))
     xs.subscriptions.assert_equal(subscribe(200, 570))
 
 def test_group_by_inner_complete_all():
     #var innerSubscriptions, inners, outer, outerSubscription, results, scheduler, xs;
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, "error"), on_next(110, "error"), on_next(130, "error"), on_next(220, "  foo"), on_next(240, " FoO "), on_next(270, "baR  "), on_next(310, "foO "), on_next(350, " Baz   "), on_next(360, "  qux "), on_next(390, "   bar"), on_next(420, " BAR  "), on_next(470, "FOO "), on_next(480, "baz  "), on_next(510, " bAZ "), on_next(530, "    fOo    "), on_completed(570), on_next(580, "error"), on_completed(600), on_error(650, 'ex'))
-    outer = None
-    outer_subscription = None
     inners = {}
     inner_subscriptions = {}
     results = {}
-    result = None
+    c = {
+        "outer": None,
+        "outer_subscription": None,
+        "result": None
+    }
 
     def action1(scheduler, state):
-        nonlocal outer
-        outer = xs.group_by(
+        c["outer"] = xs.group_by(
             lambda x: x.lower().strip(), 
             lambda x: x[::-1]
         )
-        return outer
+        return c["outer"]
     scheduler.schedule_absolute(created, action1)
 
     def action2(scheduler, state):
-        nonlocal outer_subscription
 
         def on_next(group):
-            nonlocal result, inners, results, inner_subscriptions
-            result = scheduler.create_observer()
+            c["result"] = scheduler.create_observer()
             inners[group.key] = group
-            results[group.key] = result
-            inner_subscriptions[group.key] = group.subscribe(result)
-        outer_subscription = outer.subscribe(on_next)
-        return outer_subscription
+            results[group.key] = c["result"]
+            inner_subscriptions[group.key] = group.subscribe(c["result"])
+        c["outer_subscription"] = c["outer"].subscribe(on_next)
+        return c["outer_subscription"]
     scheduler.schedule_absolute(subscribed, action2)
 
     def action3(scheduler, state):
-        outer_subscription.dispose()
+        c["outer_subscription"].dispose()
         for sub in inner_subscriptions.values():
             sub.dispose()
     scheduler.schedule_absolute(disposed, action3)
@@ -289,43 +275,41 @@ def test_group_by_inner_error():
     ex = 'ex1'
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, "error"), on_next(110, "error"), on_next(130, "error"), on_next(220, "  foo"), on_next(240, " FoO "), on_next(270, "baR  "), on_next(310, "foO "), on_next(350, " Baz   "), on_next(360, "  qux "), on_next(390, "   bar"), on_next(420, " BAR  "), on_next(470, "FOO "), on_next(480, "baz  "), on_next(510, " bAZ "), on_next(530, "    fOo    "), on_error(570, ex), on_next(580, "error"), on_completed(600), on_error(650, 'ex'))
-    outer_subscription = None
     inner_subscriptions = {}
     inners = {}
-    outer = None
     results = {}
-    result = None
+    c = {
+        "outer_subscription": None,
+        "outer": None,
+        "result": None
+    }
 
     def action1(scheduler, state):
-        nonlocal outer
-        outer = xs.group_by(
+        c["outer"] = xs.group_by(
             lambda x: x.lower().strip(), 
             lambda x: x[::-1]
         )
-        return outer
+        return c["outer"]
     scheduler.schedule_absolute(created, action1)
 
     def action2(scheduler, state):
-        nonlocal outer_subscription
 
         def on_next(group):
-            nonlocal result, inners, results
 
-            result = scheduler.create_observer()
+            c["result"] = scheduler.create_observer()
             inners[group.key] = group
-            results[group.key] = result
+            results[group.key] = c["result"]
 
             def action3(scheduler, state):
-                nonlocal inner_subscriptions
-                inner_subscriptions[group.key] = group.subscribe(result)
+                inner_subscriptions[group.key] = group.subscribe(c["result"])
             
             scheduler.schedule_relative(100, action3)
-        outer_subscription = outer.subscribe(on_next, lambda e: None)
-        return outer_subscription
+        c["outer_subscription"] = c["outer"].subscribe(on_next, lambda e: None)
+        return c["outer_subscription"]
     scheduler.schedule_absolute(subscribed, action2)
 
     def action4(scheduler, state):
-        outer_subscription.dispose();
+        c["outer_subscription"].dispose();
         for sub in inner_subscriptions.values():
             sub.dispose()
     scheduler.schedule_absolute(disposed, action4)

--- a/tests/test_standardqueryoperators/test_select_many.py
+++ b/tests/test_standardqueryoperators/test_select_many.py
@@ -190,16 +190,15 @@ def test_select_many_dispose():
     xs.messages[6].value.value.subscriptions.assert_equal()
 
 def test_select_many_throw():
-    invoked = 0
+    invoked = [0]
     ex = 'ex'
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(5, scheduler.create_cold_observable(on_error(1, 'ex1'))), on_next(105, scheduler.create_cold_observable(on_error(1, 'ex2'))), on_next(300, scheduler.create_cold_observable(on_next(10, 102), on_next(90, 103), on_next(110, 104), on_next(190, 105), on_next(440, 106), on_completed(460))), on_next(400, scheduler.create_cold_observable(on_next(180, 202), on_next(190, 203), on_completed(205))), on_next(550, scheduler.create_cold_observable(on_next(10, 301), on_next(50, 302), on_next(70, 303), on_next(260, 304), on_next(310, 305), on_completed(410))), on_next(750, scheduler.create_cold_observable(on_completed(40))), on_next(850, scheduler.create_cold_observable(on_next(80, 401), on_next(90, 402), on_completed(100))), on_completed(900))
     
     def factory():
         def projection(x):
-            nonlocal invoked
-            invoked += 1
-            if invoked == 3:
+            invoked[0] += 1
+            if invoked[0] == 3:
                 raise Exception(ex)
             return x
         return xs.select_many(projection)

--- a/tests/test_standardqueryoperators/test_skip_while.py
+++ b/tests/test_standardqueryoperators/test_skip_while.py
@@ -12,134 +12,126 @@ created = ReactiveTest.created
 def test_skip_while_complete_before():
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_completed(330), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
-    invoked = 0
+    invoked = [0]
 
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.skip_while(predicate)
     results = scheduler.start(create)
             
     results.messages.assert_equal(on_completed(330))
     xs.subscriptions.assert_equal(subscribe(200, 330))
-    assert(invoked == 4)
+    assert(invoked[0] == 4)
 
 def test_skip_while_complete_after():
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
-    invoked = 0
+    invoked = [0]
     
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.skip_while(predicate)
     results = scheduler.start(create)
         
     results.messages.assert_equal(on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
     xs.subscriptions.assert_equal(subscribe(200, 600))
-    assert(invoked == 6)
+    assert(invoked[0] == 6)
 
 def test_skip_while_error_before():
     ex = 'ex'
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(210, 2), on_next(260, 5), on_error(270, ex), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
-    invoked = 0
+    invoked = [0]
 
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.skip_while(predicate)
     results = scheduler.start(create)
             
     results.messages.assert_equal(on_error(270, ex))
     xs.subscriptions.assert_equal(subscribe(200, 270))
-    assert(invoked == 2)
+    assert(invoked[0] == 2)
 
 def test_skip_while_error_after():
     ex = 'ex'
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_error(600, ex))
-    invoked = 0
+    invoked = [0]
     
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.skip_while(predicate)
     results = scheduler.start(create)
             
     results.messages.assert_equal(on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_error(600, ex))
     xs.subscriptions.assert_equal(subscribe(200, 600))
-    assert(invoked == 6)
+    assert(invoked[0] == 6)
 
 def test_skip_while_dispose_before():
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
-    invoked = 0
+    invoked = [0]
     
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.skip_while(predicate)
     results = scheduler.start(create, disposed=300)
 
     results.messages.assert_equal()
     xs.subscriptions.assert_equal(subscribe(200, 300))
-    assert(invoked == 3)
+    assert(invoked[0] == 3)
 
 def test_skip_while_dispose_after():
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
-    invoked = 0
+    invoked = [0]
 
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.skip_while(predicate)
     results = scheduler.start(create, disposed=470)
 
     results.messages.assert_equal(on_next(390, 4), on_next(410, 17), on_next(450, 8))
     xs.subscriptions.assert_equal(subscribe(200, 470))
-    assert(invoked == 6)
+    assert(invoked[0] == 6)
 
 def test_skip_while_zero():
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(205, 100), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
-    invoked = 0
+    invoked = [0]
     
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.skip_while(predicate)
     results = scheduler.start(create)
             
     results.messages.assert_equal(on_next(205, 100), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
     xs.subscriptions.assert_equal(subscribe(200, 600))
-    assert(invoked == 1)
+    assert(invoked[0] == 1)
 
 def test_skip_while_throw():
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
     ex = 'ex'
-    invoked = 0
+    invoked = [0]
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
-            if invoked == 3:
+            invoked[0] += 1
+            if invoked[0] == 3:
                 raise Exception(ex)
             
             return is_prime(x)
@@ -148,7 +140,7 @@ def test_skip_while_throw():
     
     results.messages.assert_equal(on_error(290, ex))
     xs.subscriptions.assert_equal(subscribe(200, 290))
-    assert(invoked == 3)
+    assert(invoked[0] == 3)
 
 def test_skip_while_index():
     scheduler = TestScheduler()

--- a/tests/test_standardqueryoperators/test_take_while.py
+++ b/tests/test_standardqueryoperators/test_take_while.py
@@ -12,131 +12,123 @@ created = ReactiveTest.created
 def test_take_while_complete_Before():
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_completed(330), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
-    invoked = 0
+    invoked = [0]
 
     def factory():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.take_while(predicate)
     results = scheduler.start(factory)
         
     results.messages.assert_equal(on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_completed(330))
     xs.subscriptions.assert_equal(subscribe(200, 330))
-    assert(invoked == 4)
+    assert(invoked[0] == 4)
 
 def test_take_while_complete_after():
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
-    invoked = 0
+    invoked = [0]
 
     def factory():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.take_while(predicate)
     results = scheduler.start(factory)
         
     results.messages.assert_equal(on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_completed(390))
     xs.subscriptions.assert_equal(subscribe(200, 390))
-    assert(invoked == 6)
+    assert(invoked[0] == 6)
 
 def test_take_while_error_before():
     ex = 'ex'
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(210, 2), on_next(260, 5), on_error(270, ex), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23))
-    invoked = 0
+    invoked = [0]
 
     def factory():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.take_while(predicate)
     results = scheduler.start(factory)
             
     results.messages.assert_equal(on_next(210, 2), on_next(260, 5), on_error(270, ex))
     xs.subscriptions.assert_equal(subscribe(200, 270))
-    assert(invoked == 2)
+    assert(invoked[0] == 2)
 
 def test_take_while_error_after():
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_error(600, 'ex'))
-    invoked = 0
+    invoked = [0]
 
     def factory():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.take_while(predicate)
     results = scheduler.start(factory)
         
     results.messages.assert_equal(on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_completed(390))
     xs.subscriptions.assert_equal(subscribe(200, 390))
-    assert(invoked == 6)
+    assert(invoked[0] == 6)
 
 def test_take_while_dispose_before():
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
-    invoked = 0
+    invoked = [0]
 
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.take_while(predicate)
     results = scheduler.start(create, disposed=300)
     results.messages.assert_equal(on_next(210, 2), on_next(260, 5), on_next(290, 13))
     xs.subscriptions.assert_equal(subscribe(200, 300))
-    assert(invoked == 3)
+    assert(invoked[0] == 3)
 
 def test_take_while_dispose_after():
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
-    invoked = 0
+    invoked = [0]
 
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.take_while(predicate)
     results = scheduler.start(create, disposed=400)
     results.messages.assert_equal(on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_completed(390))
     xs.subscriptions.assert_equal(subscribe(200, 390))
-    assert(invoked == 6)
+    assert(invoked[0] == 6)
 
 def test_take_while_zero():
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(205, 100), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
-    invoked = 0
+    invoked = [0]
 
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.take_while(predicate)
     results = scheduler.start(create, disposed=300)
     results.messages.assert_equal(on_completed(205))
     xs.subscriptions.assert_equal(subscribe(200, 205))
-    assert (invoked == 1)
+    assert (invoked[0] == 1)
 
 def test_take_while_throw():
     ex = 'ex'
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(on_next(90, -1), on_next(110, -1), on_next(210, 2), on_next(260, 5), on_next(290, 13), on_next(320, 3), on_next(350, 7), on_next(390, 4), on_next(410, 17), on_next(450, 8), on_next(500, 23), on_completed(600))
-    invoked = 0
+    invoked = [0]
 
     def factory():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
-            if invoked == 3:
+            invoked[0] += 1
+            if invoked[0] == 3:
                 raise Exception(ex)
         
             return is_prime(x)
@@ -145,7 +137,7 @@ def test_take_while_throw():
             
     results.messages.assert_equal(on_next(210, 2), on_next(260, 5), on_error(290, ex))
     xs.subscriptions.assert_equal(subscribe(200, 290))
-    assert(invoked == 3)
+    assert(invoked[0] == 3)
 
 def test_take_while_index():
     scheduler = TestScheduler()

--- a/tests/test_standardqueryoperators/test_where.py
+++ b/tests/test_standardqueryoperators/test_where.py
@@ -30,13 +30,12 @@ def test_is_prime():
 
 def test_where_complete():
     scheduler = TestScheduler()
-    invoked = 0
+    invoked = [0]
     xs = scheduler.create_hot_observable(on_next(110, 1), on_next(180, 2), on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_completed(600), on_next(610, 12), on_error(620, 'ex'), on_completed(630))
     
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         
         return xs.where(predicate)
@@ -45,34 +44,32 @@ def test_where_complete():
 
     results.messages.assert_equal(on_next(230, 3), on_next(340, 5), on_next(390, 7), on_next(580, 11), on_completed(600))
     xs.subscriptions.assert_equal(subscribe(200, 600))
-    assert invoked == 9
+    assert invoked[0] == 9
 
 def test_where_true():
     scheduler = TestScheduler()
-    invoked = 0
+    invoked = [0]
     xs = scheduler.create_hot_observable(on_next(110, 1), on_next(180, 2), on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_completed(600))
     
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return True
         return xs.where(predicate)
    
     results = scheduler.start(create)
     results.messages.assert_equal(on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_completed(600))
     xs.subscriptions.assert_equal(subscribe(200, 600))
-    assert invoked == 9
+    assert invoked[0] == 9
 
 def test_where_false():
     scheduler = TestScheduler()
-    invoked = 0
+    invoked = [0]
     xs = scheduler.create_hot_observable(on_next(110, 1), on_next(180, 2), on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_completed(600))
     
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return False
 
         return xs.where(predicate)
@@ -81,35 +78,33 @@ def test_where_false():
 
     results.messages.assert_equal(on_completed(600))
     xs.subscriptions.assert_equal(subscribe(200, 600))
-    assert invoked == 9
+    assert invoked[0] == 9
 
 def test_where_dispose():
     scheduler = TestScheduler()
-    invoked = 0
+    invoked = [0]
     xs = scheduler.create_hot_observable(on_next(110, 1), on_next(180, 2), on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_completed(600))
     
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.where(predicate)
     
     results = scheduler.start(create, disposed=400)
     results.messages.assert_equal(on_next(230, 3), on_next(340, 5), on_next(390, 7))
     xs.subscriptions.assert_equal(subscribe(200, 400))
-    assert invoked == 5
+    assert invoked[0] == 5
 
 def test_where_error():
     scheduler = TestScheduler()
-    invoked = 0
+    invoked = [0]
     ex = 'ex'
     xs = scheduler.create_hot_observable(on_next(110, 1), on_next(180, 2), on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_error(600, ex), on_next(610, 12), on_error(620, 'ex'), on_completed(630))
     
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x)
         return xs.where(predicate)
 
@@ -117,18 +112,17 @@ def test_where_error():
         
     results.messages.assert_equal(on_next(230, 3), on_next(340, 5), on_next(390, 7), on_next(580, 11), on_error(600, ex))
     xs.subscriptions.assert_equal(subscribe(200, 600))
-    assert invoked == 9
+    assert invoked[0] == 9
 
 def test_where_throw():
     scheduler = TestScheduler()
-    invoked = 0
+    invoked = [0]
     ex = 'ex'
     xs = scheduler.create_hot_observable(on_next(110, 1), on_next(180, 2), on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_completed(600), on_next(610, 12), on_error(620, 'ex'), on_completed(630))
     
     def create():
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             if x > 5:
                 raise Exception(ex)
             
@@ -139,33 +133,31 @@ def test_where_throw():
         
     results.messages.assert_equal(on_next(230, 3), on_next(340, 5), on_error(380, ex))
     xs.subscriptions.assert_equal(subscribe(200, 380))
-    assert invoked == 4
+    assert invoked[0] == 4
 
 def test_where_dispose_in_predicate():
     scheduler = TestScheduler()
-    invoked = 0
-    ys = None
+    invoked = [0]
+    ys = [None]
     xs = scheduler.create_hot_observable(on_next(110, 1), on_next(180, 2), on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_completed(600), on_next(610, 12), on_error(620, 'ex'), on_completed(630))
     results = scheduler.create_observer()
     d = SerialDisposable()
     
     def action(scheduler, state):
-        nonlocal ys
 
         def predicate(x):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             if x == 8:
                 d.dispose()
             
             return is_prime(x)
-        ys = xs.where(predicate)
-        return ys
+        ys[0] = xs.where(predicate)
+        return ys[0]
 
     scheduler.schedule_absolute(created, action)
     
     def action1(scheduler, state):
-        d.disposable = ys.subscribe(results)
+        d.disposable = ys[0].subscribe(results)
 
     scheduler.schedule_absolute(subscribed, action1)
 
@@ -177,17 +169,16 @@ def test_where_dispose_in_predicate():
     scheduler.start()
     results.messages.assert_equal(on_next(230, 3), on_next(340, 5), on_next(390, 7))
     xs.subscriptions.assert_equal(subscribe(200, 450))
-    assert invoked == 6
+    assert invoked[0] == 6
 
 def test_where_index_complete():
     scheduler = TestScheduler()
-    invoked = 0
+    invoked = [0]
     xs = scheduler.create_hot_observable(on_next(110, 1), on_next(180, 2), on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_completed(600), on_next(610, 12), on_error(620, 'ex'), on_completed(630))
     
     def create():
         def predicate(x, index):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x + index * 10)
         
         return xs.where(predicate)
@@ -195,17 +186,16 @@ def test_where_index_complete():
     results = scheduler.start(create)
     results.messages.assert_equal(on_next(230, 3), on_next(390, 7), on_completed(600))
     xs.subscriptions.assert_equal(subscribe(200, 600))
-    assert invoked == 9
+    assert invoked[0] == 9
     
 def test_where_index_true():
     scheduler = TestScheduler()
-    invoked = 0
+    invoked = [0]
     xs = scheduler.create_hot_observable(on_next(110, 1), on_next(180, 2), on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_completed(600))
 
     def create():
         def predicate(x, index):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return True
 
         return xs.where(predicate)
@@ -213,17 +203,16 @@ def test_where_index_true():
     results = scheduler.start(create)
     results.messages.assert_equal(on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_completed(600))
     xs.subscriptions.assert_equal(subscribe(200, 600))
-    assert invoked == 9
+    assert invoked[0] == 9
 
 def test_where_index_false():
     scheduler = TestScheduler()
-    invoked = 0
+    invoked = [0]
     xs = scheduler.create_hot_observable(on_next(110, 1), on_next(180, 2), on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_completed(600))
 
     def create():
         def predicate(x, index):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return False
         return xs.where(predicate)
     
@@ -231,17 +220,16 @@ def test_where_index_false():
 
     results.messages.assert_equal(on_completed(600))
     xs.subscriptions.assert_equal(subscribe(200, 600))
-    assert invoked == 9
+    assert invoked[0] == 9
 
 def test_where_index_dispose():
     scheduler = TestScheduler()
-    invoked = 0
+    invoked = [0]
     xs = scheduler.create_hot_observable(on_next(110, 1), on_next(180, 2), on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_completed(600))
     
     def create():
         def predicate(x, index):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x + index * 10)
         
         return xs.where(predicate)
@@ -249,18 +237,17 @@ def test_where_index_dispose():
     results = scheduler.start(create, disposed=400)
     results.messages.assert_equal(on_next(230, 3), on_next(390, 7))
     xs.subscriptions.assert_equal(subscribe(200, 400))
-    assert invoked == 5
+    assert invoked[0] == 5
 
 def test_where_index_error():
     scheduler = TestScheduler()
-    invoked = 0
+    invoked = [0]
     ex = 'ex'
     xs = scheduler.create_hot_observable(on_next(110, 1), on_next(180, 2), on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_error(600, ex), on_next(610, 12), on_error(620, 'ex'), on_completed(630))
     
     def create():
         def predicate(x, index):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             return is_prime(x + index * 10)
         return xs.where(predicate)
 
@@ -268,18 +255,17 @@ def test_where_index_error():
     
     results.messages.assert_equal(on_next(230, 3), on_next(390, 7), on_error(600, ex))
     xs.subscriptions.assert_equal(subscribe(200, 600))
-    assert invoked == 9
+    assert invoked[0] == 9
 
 def test_where_index_throw():
     scheduler = TestScheduler()
-    invoked = 0
+    invoked = [0]
     ex = 'ex'
     xs = scheduler.create_hot_observable(on_next(110, 1), on_next(180, 2), on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_completed(600), on_next(610, 12), on_error(620, 'ex'), on_completed(630))
 
     def create():
         def predicate(x, index):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             if x > 5:
                 raise Exception(ex)
 
@@ -289,31 +275,29 @@ def test_where_index_throw():
     results = scheduler.start(create)
     results.messages.assert_equal(on_next(230, 3), on_error(380, ex))
     xs.subscriptions.assert_equal(subscribe(200, 380))
-    assert invoked == 4
+    assert invoked[0] == 4
 
 def test_where_index_dispose_in_predicate():
     scheduler = TestScheduler()
-    ys = None
-    invoked = 0
+    ys = [None]
+    invoked = [0]
     xs = scheduler.create_hot_observable(on_next(110, 1), on_next(180, 2), on_next(230, 3), on_next(270, 4), on_next(340, 5), on_next(380, 6), on_next(390, 7), on_next(450, 8), on_next(470, 9), on_next(560, 10), on_next(580, 11), on_completed(600), on_next(610, 12), on_error(620, 'ex'), on_completed(630))
     results = scheduler.create_observer()
     d = SerialDisposable()
     
     def action1(scheduler, state):
-        nonlocal ys
         def predicate(x, index):
-            nonlocal invoked
-            invoked += 1
+            invoked[0] += 1
             if x == 8:
                 d.dispose()
             
             return is_prime(x + index * 10)
-        ys = xs.where(predicate)
+        ys[0] = xs.where(predicate)
 
     scheduler.schedule_absolute(created, action1)
     
     def action2(scheduler, state):
-         d.disposable = ys.subscribe(results)
+         d.disposable = ys[0].subscribe(results)
 
     scheduler.schedule_absolute(subscribed, action2)
     
@@ -325,4 +309,4 @@ def test_where_index_dispose_in_predicate():
     scheduler.start()
     results.messages.assert_equal(on_next(230, 3), on_next(390, 7))
     xs.subscriptions.assert_equal(subscribe(200, 450))
-    assert invoked == 6
+    assert invoked[0] == 6

--- a/tests/test_subject.py
+++ b/tests/test_subject.py
@@ -21,11 +21,11 @@ def _raise(ex):
     raise RxException(ex)
 
 def test_infinite():
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
-    s = None
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
+    s = [None]
     scheduler = TestScheduler()
 
     xs = scheduler.create_hot_observable(
@@ -48,48 +48,43 @@ def test_infinite():
     results3 = scheduler.create_observer()
 
     def action1(scheduler, state=None):
-        nonlocal s
-        s = Subject()
+        s[0] = Subject()
     scheduler.schedule_absolute(100, action1)
     
     def action2(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(s)
+        subscription[0] = xs.subscribe(s[0])
     scheduler.schedule_absolute(200, action2)
     
     def action3(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action3)
 
     def action4(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = s.subscribe(results1)
+        subscription1[0] = s[0].subscribe(results1)
     scheduler.schedule_absolute(300, action4)
 
     def action5(scheduler, state=None):    
-        nonlocal subscription2
-        subscription2 = s.subscribe(results2)
+        subscription2[0] = s[0].subscribe(results2)
     scheduler.schedule_absolute(400, action5)
     
     def action6(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = s.subscribe(results3)
+        subscription3[0] = s[0].subscribe(results3)
     scheduler.schedule_absolute(900, action6)
     
     def action7(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action7)
     
     def action8(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action8)
     
     def action9(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action9)
     
     def action10(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action10)
     
     scheduler.start()
@@ -110,11 +105,11 @@ def test_infinite():
 
 def test_finite():
     scheduler = TestScheduler()
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
-    s = None
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
+    s = [None]
     
     xs = scheduler.create_hot_observable(
         on_next(70, 1),
@@ -135,48 +130,43 @@ def test_finite():
     results3 = scheduler.create_observer()
 
     def action1(scheduler, state=None):
-        nonlocal s
-        s = Subject()
+        s[0] = Subject()
     scheduler.schedule_absolute(100, action1)
         
     def action2(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(s)
+        subscription[0] = xs.subscribe(s[0])
     scheduler.schedule_absolute(200, action2)
     
     def action3(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action3)
         
     def action4(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = s.subscribe(results1)
+        subscription1[0] = s[0].subscribe(results1)
     scheduler.schedule_absolute(300, action4)
     
     def action5(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = s.subscribe(results2)    
+        subscription2[0] = s[0].subscribe(results2)
     scheduler.schedule_absolute(400, action5)
     
     def action6(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = s.subscribe(results3)
+        subscription3[0] = s[0].subscribe(results3)
     scheduler.schedule_absolute(900, action6)
     
     def action7(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action7)
     
     def action8(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action8)
     
     def action9(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action9)
     
     def action10(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action10)
     
     scheduler.start()
@@ -196,11 +186,11 @@ def test_finite():
     )
 
 def test_error():
-    s = None
-    subscription = None
-    subscription1 = None 
-    subscription2 = None
-    subscription3 = None
+    s = [None]
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
     ex = 'ex'
 
     scheduler = TestScheduler()
@@ -224,48 +214,43 @@ def test_error():
     results3 = scheduler.create_observer()
 
     def action(scheduler, state=None):
-        nonlocal s
-        s = Subject()
+        s[0] = Subject()
     scheduler.schedule_absolute(100, action)
     
     def action1(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(s)
+        subscription[0] = xs.subscribe(s[0])
     scheduler.schedule_absolute(200, action1)
     
     def action2(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action2)
     
     def action3(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = s.subscribe(results1)
+        subscription1[0] = s[0].subscribe(results1)
     scheduler.schedule_absolute(300, action3)
     
     def action4(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = s.subscribe(results2)
+        subscription2[0] = s[0].subscribe(results2)
     scheduler.schedule_absolute(400, action4)
     
     def action5(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = s.subscribe(results3)
+        subscription3[0] = s[0].subscribe(results3)
     scheduler.schedule_absolute(900, action5)
     
     def action6(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action6)
     
     def action7(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action7)
     
     def action8(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action8)
     
     def action9(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action9)
     
     scheduler.start()
@@ -275,11 +260,11 @@ def test_error():
     results3.messages.assert_equal(on_error(900, ex))
 
 def test_canceled():
-    s = None 
-    subscription = None
-    subscription1 = None
-    subscription2 = None
-    subscription3 = None
+    s = [None]
+    subscription = [None]
+    subscription1 = [None]
+    subscription2 = [None]
+    subscription3 = [None]
 
     scheduler = TestScheduler()
     xs = scheduler.create_hot_observable(
@@ -294,48 +279,43 @@ def test_canceled():
     results3 = scheduler.create_observer()
 
     def action1(scheduler, state=None):
-        nonlocal s
-        s = Subject()
+        s[0] = Subject()
     scheduler.schedule_absolute(100, action1)
     
     def action2(scheduler, state=None):
-        nonlocal subscription
-        subscription = xs.subscribe(s)
+        subscription[0] = xs.subscribe(s[0])
     scheduler.schedule_absolute(200, action2)
     
     def action3(scheduler, state=None):
-        subscription.dispose()
+        subscription[0].dispose()
     scheduler.schedule_absolute(1000, action3)
     
     def action4(scheduler, state=None):
-        nonlocal subscription1
-        subscription1 = s.subscribe(results1)
+        subscription1[0] = s[0].subscribe(results1)
     scheduler.schedule_absolute(300, action4)
     
     def action5(scheduler, state=None):
-        nonlocal subscription2
-        subscription2 = s.subscribe(results2)
+        subscription2[0] = s[0].subscribe(results2)
     scheduler.schedule_absolute(400, action5)
     
     def action6(scheduler, state=None):
-        nonlocal subscription3
-        subscription3 = s.subscribe(results3)
+        subscription3[0] = s[0].subscribe(results3)
     scheduler.schedule_absolute(900, action6)
     
     def action7(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(600, action7)
     
     def action8(scheduler, state=None):
-        subscription2.dispose()
+        subscription2[0].dispose()
     scheduler.schedule_absolute(700, action8)
     
     def action9(scheduler, state=None):
-        subscription1.dispose()
+        subscription1[0].dispose()
     scheduler.schedule_absolute(800, action9)
     
     def action10(scheduler, state=None):
-        subscription3.dispose()
+        subscription3[0].dispose()
     scheduler.schedule_absolute(950, action10)
     
     scheduler.start()
@@ -345,17 +325,15 @@ def test_canceled():
     results3.messages.assert_equal(on_completed(900))
 
 def test_subject_create():
-    _x = None 
-    _ex = None 
+    _x = [None]
+    _ex = [None]
     done = False
 
     def on_next(x):
-        nonlocal _x
-        _x = x
+        _x[0] = x
 
     def on_error(ex):
-        nonlocal _ex
-        _ex = ex
+        _ex[0] = ex
     
     def on_completed():
         done = True
@@ -367,17 +345,16 @@ def test_subject_create():
     s = Subject.create(v, o)
 
     def on_next2(x):
-        nonlocal _x
-        _x = x
+        _x[0] = x
     s.subscribe(on_next2)
 
-    assert(42 == _x)
+    assert(42 == _x[0])
     s.on_next(21)
 
     e = 'ex'
     s.on_error(e)
 
-    assert(e == _ex)
+    assert(e == _ex[0])
 
     s.on_completed()
     assert(not done)

--- a/tests/test_timeoutscheduler.py
+++ b/tests/test_timeoutscheduler.py
@@ -9,30 +9,28 @@ def test_timeout_now():
 
 def test_timeout_schedule_action():
     scheduler = TimeoutScheduler()
-    ran = False
+    ran = [False]
     
     def action(scheduler, state):
-        nonlocal ran
-        ran = True
+        ran[0] = True
 
     scheduler.schedule(action)
 
     sleep(0.1)
-    assert (ran == True)
+    assert (ran[0] == True)
 
 def test_thread_pool_schedule_action_due():
     scheduler = TimeoutScheduler()
     starttime = datetime.utcnow()
-    endtime = None
+    endtime = [None]
     
     def action(scheduler, state):
-        nonlocal endtime
-        endtime = datetime.utcnow()
+        endtime[0] = datetime.utcnow()
     
     scheduler.schedule_relative(timedelta(milliseconds=200), action)
 
     sleep(0.3)
-    diff = endtime-starttime
+    diff = endtime[0]-starttime
     assert(diff > timedelta(milliseconds=180))
     
 def test_timeout_schedule_action_cancel():


### PR DESCRIPTION
This adds compatibility with the more widely used python 2.7. There are two downsides to this PR:
1. It adds a dependency on six, a compatibility library for python 2.x and 3.x
2. Because of the lack of the `nonlocal` directive, all mutable closure variables are wrapped in a (mutable) array with length 1.

There are ways around these warts, but to me the fixes are almost as bad.
